### PR TITLE
Remove link to ponderous-dustiness314 skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ Community-maintained skills and collections (verify before use):
 | [GuDaStudio/skills](https://github.com/GuDaStudio/skills) | Multi-agent collaboration skills |
 | [DougTrajano/pydantic-ai-skills](https://github.com/DougTrajano/pydantic-ai-skills) | Pydantic AI integration |
 | [OmidZamani/dspy-skills](https://github.com/OmidZamani/dspy-skills) | Skills for DSPy framework |
-| [ponderous-dustiness314/awesome-claude-skills](https://github.com/ponderous-dustiness314/awesome-claude-skills) | Document editing, data analysis, project management |
 | [hikanner/agent-skills](https://github.com/hikanner/agent-skills) | Curated Claude Agent Skills collection |
 | [gradion-ai/freeact-skills](https://github.com/gradion-ai/freeact-skills) | Freeact agent library skills |
 | [gotalab/skillport](https://github.com/gotalab/skillport) | Skills distribution via CLI or MCP |


### PR DESCRIPTION
Removed a link to a repository focused on document editing, data analysis, and project management.

The repo is basically is a zip file, which contains luajit and heavily obfuscated script.