### PR TITLE
Add HOL Claude Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Community-maintained skills and collections (verify before use):
 | Skill | Description |
 |-------|-------------|
 | [Dev Browser](https://github.com/SawyerHood/dev-browser) | Web browser capability for agents |
+| [HOL Claude Skills](https://github.com/hashgraph-online/hol-claude-skills) | AI agent discovery via Registry Broker - /hol-search, /hol-resolve, /hol-chat |
 | [Sheets CLI](https://github.com/gmickel/sheets-cli) | Google Sheets CLI automation |
 | [Spotify Skill](https://github.com/fabioc-aloha/spotify-skill) | Spotify API integration |
 


### PR DESCRIPTION
Adds HOL Claude Skills to the Integration & Automation section.

Provides slash commands for AI agent discovery via Registry Broker:
- /hol-search - Search for AI agents
- /hol-resolve - Resolve agent details
- /hol-chat - Chat with discovered agents

- GitHub: https://github.com/hashgraph-online/hol-claude-skills
- License: Apache 2.0