### PR TITLE
Add dmgrok/agent_skills_directory to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Community-maintained skills and collections (verify before use):
 | [OmidZamani/dspy-skills](https://github.com/OmidZamani/dspy-skills) | Skills for DSPy framework |
 | [hikanner/agent-skills](https://github.com/hikanner/agent-skills) | Curated Claude Agent Skills collection |
 | [gradion-ai/freeact-skills](https://github.com/gradion-ai/freeact-skills) | Freeact agent library skills |
+| [dmgrok/agent_skills_directory](https://github.com/dmgrok/agent_skills_directory) | npm-like CLI for skills (`brew install dmgrok/tap/skills`) - aggregates 177+ skills from 24 providers |
 | [gotalab/skillport](https://github.com/gotalab/skillport) | Skills distribution via CLI or MCP |
 | [mhattingpete/claude-skills-marketplace](https://github.com/mhattingpete/claude-skills-marketplace) | Git, code review, and testing skills |
 | [kukapay/crypto-skills](https://github.com/kukapay/crypto-skills) |  cryptocurrency, web3 and blockchain skills. |


### PR DESCRIPTION
## What's being added

Adding `dmgrok/agent_skills_directory` to the **Skill Collections** table - an npm-like CLI that aggregates skills from 24 provider repos.

## Why it fits

Similar to `gotalab/skillport` already listed ("Skills distribution via CLI or MCP"), this provides:
- CLI-based skill installation: `brew install dmgrok/tap/skills`
- Aggregation from Anthropic, OpenAI, GitHub, Vercel, HuggingFace + 19 community repos
- 177+ skills with daily automated updates
- Web catalog: https://dmgrok.github.io/agent_skills_directory/

## Checklist

- [x] Verified skill exists and links work
- [x] Follows table format exactly
- [x] Real use case (package management for skills)
- [x] No duplicates in existing list