### PR TITLE
docs: add Gemini CLI and sync community skills in translations

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -57,6 +57,8 @@ Las siguientes plataformas tienen soporte documentado para Agent Skills:
 | Codex (OpenAI) | [developers.openai.com](https://developers.openai.com/codex/skills) |
 | GitHub Copilot | [docs.github.com](https://docs.github.com/copilot/concepts/agents/about-agent-skills) |
 | VS Code | [code.visualstudio.com](https://code.visualstudio.com/docs/copilot/customization/agent-skills) |
+| Antigravity | [antigravity.google](https://antigravity.google/docs/skills) |
+| Gemini CLI | [geminicli.com](https://geminicli.com/docs/cli/skills/) |
 
 ---
 
@@ -108,6 +110,15 @@ Habilidades y colecciones mantenidas por la comunidad (verificar antes de usar):
 | [huggingface/skills](https://github.com/huggingface/skills) | Habilidades de HuggingFace (compatible con Claude, Codex, Gemini) |
 | [skillcreatorai/Ai-Agent-Skills](https://github.com/skillcreatorai/Ai-Agent-Skills) | Colección de SkillCreator.ai con instalador CLI |
 | [karanb192/awesome-claude-skills](https://github.com/karanb192/awesome-claude-skills) | Más de 50 habilidades verificadas para Claude Code y Claude.ai |
+| [shajith003/awesome-claude-skills](https://github.com/shajith003/awesome-claude-skills) | Habilidades para capacidades especializadas |
+| [GuDaStudio/skills](https://github.com/GuDaStudio/skills) | Habilidades de colaboración multi-agente |
+| [DougTrajano/pydantic-ai-skills](https://github.com/DougTrajano/pydantic-ai-skills) | Integración con Pydantic AI |
+| [OmidZamani/dspy-skills](https://github.com/OmidZamani/dspy-skills) | Habilidades para el framework DSPy |
+| [hikanner/agent-skills](https://github.com/hikanner/agent-skills) | Colección seleccionada de Agent Skills para Claude |
+| [gradion-ai/freeact-skills](https://github.com/gradion-ai/freeact-skills) | Habilidades de la librería de agentes Freeact |
+| [gotalab/skillport](https://github.com/gotalab/skillport) | Distribución de habilidades vía CLI o MCP |
+| [mhattingpete/claude-skills-marketplace](https://github.com/mhattingpete/claude-skills-marketplace) | Habilidades de Git, revisión de código y pruebas |
+| [kukapay/crypto-skills](https://github.com/kukapay/crypto-skills) | Habilidades de criptomonedas, web3 y blockchain. |
 
 #### Procesamiento de Documentos
 
@@ -123,6 +134,11 @@ Habilidades y colecciones mantenidas por la comunidad (verificar antes de usar):
 | [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) | Gráficos D3 y visualizaciones de datos interactivas |
 | [Playwright Automation](https://github.com/lackeyjb/playwright-skill) | Automatización del navegador para probar aplicaciones web |
 | [Specrate](https://github.com/rickygao/specrate) | Gestiona especificaciones y cambios con un flujo de trabajo estructurado |
+| [iOS Simulator](https://github.com/conorluddy/ios-simulator-skill) | Interactuar con el Simulador de iOS para pruebas |
+| [Swift Concurrency Migration](https://github.com/kylehughes/the-unofficial-swift-concurrency-migration-skill) | Guía de migración a Swift Concurrency |
+| [Obsidian Plugin](https://github.com/gapmiss/obsidian-plugin-skill) | Desarrollo de plugins para Obsidian.md |
+| [Stream Coding](https://github.com/frmoretto/stream-coding) | Metodología de Stream Coding |
+| [SwiftUI Skills](https://github.com/ameyalambat128/swiftui-skills) | Guía de plataforma y SwiftUI creada por Apple extraída de Xcode |
 
 #### Datos y Análisis
 
@@ -135,15 +151,35 @@ Habilidades y colecciones mantenidas por la comunidad (verificar antes de usar):
 | Habilidad | Descripción |
 |------|------|
 | [Dev Browser](https://github.com/SawyerHood/dev-browser) | Capacidad de navegador web para agentes |
+| [Vectorize MCP Worker](https://github.com/dannwaneri/vectorize-mcp-worker) | Patrones de servidor MCP nativos del borde para RAG en producción |
+| [Agent Manager](https://github.com/fractalmind-ai/agent-manager-skill) | Gestionar agentes de IA CLI locales vía tmux (iniciar/detener/monitorear/asignar + programación cron) |
+| [HOL Claude Skills](https://github.com/hashgraph-online/hol-claude-skills) | Descubrimiento de agentes de IA vía Registry Broker - /hol-search, /hol-resolve, /hol-chat |
 | [Sheets CLI](https://github.com/gmickel/sheets-cli) | Automatización CLI de Google Sheets |
 | [Notification Skill](https://github.com/caopulan/Notification-Skill) | Enviar notificaciones de mensajes para flujos de trabajo de agentes |
 | [Spotify Skill](https://github.com/fabioc-aloha/spotify-skill) | Integración de API de Spotify |
+
+#### Colaboración y Gestión de Proyectos
+
+| Habilidad | Descripción |
+|------|------|
+| [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace) | Automatizar operaciones git e interacciones con el repositorio |
+| [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace) | Evaluar planes de implementación de código |
+| [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace) | Detectar pruebas fallidas y proponer correcciones |
 
 #### Seguridad y Sistemas
 
 | Habilidad | Descripción |
 |------|------|
+| [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace) | Análisis e investigación forense digital |
 | [Threat Hunting](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) | Caza de amenazas usando reglas de detección Sigma |
+
+#### Avanzado e Investigación
+
+| Habilidad | Descripción |
+|------|------|
+| [Context Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) | Técnicas de ingeniería de contexto |
+| [Pomodoro System Skill](https://github.com/jakedahn/pomodoro) | Patrón de Habilidad del Sistema (habilidades que recuerdan y mejoran) |
+| [Mind Cloning](https://github.com/yzfly/Mind-Cloning-Engineering) | Clonación mental con habilidades LLM |
 
 ---
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -57,6 +57,8 @@ AI・コーディング・エージェントのためのスキル、ツール、
 | Codex (OpenAI) | [developers.openai.com](https://developers.openai.com/codex/skills) |
 | GitHub Copilot | [docs.github.com](https://docs.github.com/copilot/concepts/agents/about-agent-skills) |
 | VS Code | [code.visualstudio.com](https://code.visualstudio.com/docs/copilot/customization/agent-skills) |
+| Antigravity | [antigravity.google](https://antigravity.google/docs/skills) |
+| Gemini CLI | [geminicli.com](https://geminicli.com/docs/cli/skills/) |
 
 ---
 
@@ -108,6 +110,15 @@ Codexは異なるスコープのスキルをサポートしています：
 | [huggingface/skills](https://github.com/huggingface/skills) | HuggingFaceスキル（Claude, Codex, Gemini互換）|
 | [skillcreatorai/Ai-Agent-Skills](https://github.com/skillcreatorai/Ai-Agent-Skills) | SkillCreator.aiコレクション（CLIインストーラー付き）|
 | [karanb192/awesome-claude-skills](https://github.com/karanb192/awesome-claude-skills) | Claude CodeおよびClaude.ai向けの50以上の検証済みスキル |
+| [shajith003/awesome-claude-skills](https://github.com/shajith003/awesome-claude-skills) | 特殊機能のためのスキル |
+| [GuDaStudio/skills](https://github.com/GuDaStudio/skills) | マルチエージェントコラボレーションスキル |
+| [DougTrajano/pydantic-ai-skills](https://github.com/DougTrajano/pydantic-ai-skills) | Pydantic AI統合 |
+| [OmidZamani/dspy-skills](https://github.com/OmidZamani/dspy-skills) | DSPyフレームワーク用スキル |
+| [hikanner/agent-skills](https://github.com/hikanner/agent-skills) | 厳選されたClaudeエージェントスキルコレクション |
+| [gradion-ai/freeact-skills](https://github.com/gradion-ai/freeact-skills) | Freeactエージェントライブラリスキル |
+| [gotalab/skillport](https://github.com/gotalab/skillport) | CLIまたはMCP経由のスキル配布 |
+| [mhattingpete/claude-skills-marketplace](https://github.com/mhattingpete/claude-skills-marketplace) | Git、コードレビュー、テストスキル |
+| [kukapay/crypto-skills](https://github.com/kukapay/crypto-skills) | 暗号通貨、Web3、ブロックチェーンスキル |
 
 #### ドキュメント処理
 
@@ -123,6 +134,11 @@ Codexは異なるスコープのスキルをサポートしています：
 | [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) | D3チャートとインタラクティブなデータ視覚化 |
 | [Playwright Automation](https://github.com/lackeyjb/playwright-skill) | Webアプリテスト用のブラウザ自動化 |
 | [Specrate](https://github.com/rickygao/specrate) | 仕様（spec）と変更を構造化されたワークフローで管理 |
+| [iOS Simulator](https://github.com/conorluddy/ios-simulator-skill) | テスト用にiOSシミュレーターと対話 |
+| [Swift Concurrency Migration](https://github.com/kylehughes/the-unofficial-swift-concurrency-migration-skill) | Swift Concurrency移行ガイド |
+| [Obsidian Plugin](https://github.com/gapmiss/obsidian-plugin-skill) | Obsidian.mdプラグイン開発 |
+| [Stream Coding](https://github.com/frmoretto/stream-coding) | Stream Coding方法論 |
+| [SwiftUI Skills](https://github.com/ameyalambat128/swiftui-skills) | Xcodeから抽出されたApple作成のSwiftUIおよびプラットフォームガイダンス |
 
 #### データ・分析
 
@@ -135,15 +151,35 @@ Codexは異なるスコープのスキルをサポートしています：
 | スキル | 説明 |
 |------|------|
 | [Dev Browser](https://github.com/SawyerHood/dev-browser) | エージェント向けWebブラウザ機能 |
+| [Vectorize MCP Worker](https://github.com/dannwaneri/vectorize-mcp-worker) | 本番RAG向けのエッジネイティブMCPサーバーパターン |
+| [Agent Manager](https://github.com/fractalmind-ai/agent-manager-skill) | tmux経由でローカルCLI AIエージェントを管理（開始/停止/監視/割り当て + cronスケジュール） |
+| [HOL Claude Skills](https://github.com/hashgraph-online/hol-claude-skills) | Registry Broker経由のAIエージェント検出 - /hol-search, /hol-resolve, /hol-chat |
 | [Sheets CLI](https://github.com/gmickel/sheets-cli) | Google Sheets CLI自動化 |
 | [Notification Skill](https://github.com/caopulan/Notification-Skill) | エージェントのワークフロー向けにメッセージ通知を送信 |
 | [Spotify Skill](https://github.com/fabioc-aloha/spotify-skill) | Spotify API統合 |
+
+#### コラボレーションとプロジェクト管理
+
+| スキル | 説明 |
+|------|------|
+| [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace) | git操作とリポジトリ対話を自動化 |
+| [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace) | コード実装計画を評価 |
+| [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace) | 失敗したテストを検出し、修正を提案 |
 
 #### セキュリティ・システム
 
 | スキル | 説明 |
 |------|------|
+| [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace) | デジタルフォレンジック分析と調査 |
 | [Threat Hunting](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) | Sigma検出ルールを使用した脅威ハンティング |
+
+#### 高度な研究
+
+| スキル | 説明 |
+|------|------|
+| [Context Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) | コンテキストエンジニアリング技術 |
+| [Pomodoro System Skill](https://github.com/jakedahn/pomodoro) | システムスキルパターン（記憶し改善するスキル） |
+| [Mind Cloning](https://github.com/yzfly/Mind-Cloning-Engineering) | LLMスキルによるマインドクローニング |
 
 ---
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -57,6 +57,8 @@ AI 코딩 에이전트를 위한 엄선된 기술, 도구 및 기능 목록입�
 | Codex (OpenAI) | [developers.openai.com](https://developers.openai.com/codex/skills) |
 | GitHub Copilot | [docs.github.com](https://docs.github.com/copilot/concepts/agents/about-agent-skills) |
 | VS Code | [code.visualstudio.com](https://code.visualstudio.com/docs/copilot/customization/agent-skills) |
+| Antigravity | [antigravity.google](https://antigravity.google/docs/skills) |
+| Gemini CLI | [geminicli.com](https://geminicli.com/docs/cli/skills/) |
 
 ---
 
@@ -108,6 +110,15 @@ Codex는 다양한 범위의 스킬을 지원합니다:
 | [huggingface/skills](https://github.com/huggingface/skills) | HuggingFace 스킬 (Claude, Codex, Gemini 호환) |
 | [skillcreatorai/Ai-Agent-Skills](https://github.com/skillcreatorai/Ai-Agent-Skills) | SkillCreator.ai 컬렉션 (CLI 설치 프로그램 포함) |
 | [karanb192/awesome-claude-skills](https://github.com/karanb192/awesome-claude-skills) | Claude Code 및 Claude.ai를 위한 50개 이상의 검증된 스킬 |
+| [shajith003/awesome-claude-skills](https://github.com/shajith003/awesome-claude-skills) | 전문 기능을 위한 스킬 |
+| [GuDaStudio/skills](https://github.com/GuDaStudio/skills) | 다중 에이전트 협업 스킬 |
+| [DougTrajano/pydantic-ai-skills](https://github.com/DougTrajano/pydantic-ai-skills) | Pydantic AI 통합 |
+| [OmidZamani/dspy-skills](https://github.com/OmidZamani/dspy-skills) | DSPy 프레임워크용 스킬 |
+| [hikanner/agent-skills](https://github.com/hikanner/agent-skills) | 엄선된 Claude 에이전트 스킬 컬렉션 |
+| [gradion-ai/freeact-skills](https://github.com/gradion-ai/freeact-skills) | Freeact 에이전트 라이브러리 스킬 |
+| [gotalab/skillport](https://github.com/gotalab/skillport) | CLI 또는 MCP를 통한 스킬 배포 |
+| [mhattingpete/claude-skills-marketplace](https://github.com/mhattingpete/claude-skills-marketplace) | Git, 코드 리뷰 및 테스트 스킬 |
+| [kukapay/crypto-skills](https://github.com/kukapay/crypto-skills) | 암호화폐, web3 및 블록체인 스킬 |
 
 #### 문서 처리
 
@@ -123,6 +134,11 @@ Codex는 다양한 범위의 스킬을 지원합니다:
 | [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) | D3 차트 및 대화형 데이터 시각화 |
 | [Playwright Automation](https://github.com/lackeyjb/playwright-skill) | 웹 앱 테스트를 위한 브라우저 자동화 |
 | [Specrate](https://github.com/rickygao/specrate) | 명세(spec)와 변경을 구조화된 워크플로로 관리 |
+| [iOS Simulator](https://github.com/conorluddy/ios-simulator-skill) | 테스트를 위한 iOS 시뮬레이터 상호 작용 |
+| [Swift Concurrency Migration](https://github.com/kylehughes/the-unofficial-swift-concurrency-migration-skill) | Swift 동시성 마이그레이션 가이드 |
+| [Obsidian Plugin](https://github.com/gapmiss/obsidian-plugin-skill) | Obsidian.md 플러그인 개발 |
+| [Stream Coding](https://github.com/frmoretto/stream-coding) | 스트림 코딩 방법론 |
+| [SwiftUI Skills](https://github.com/ameyalambat128/swiftui-skills) | Xcode에서 추출한 Apple 작성 SwiftUI 및 플랫폼 지침 |
 
 #### 데이터 및 분석
 
@@ -135,15 +151,35 @@ Codex는 다양한 범위의 스킬을 지원합니다:
 | 스킬 | 설명 |
 |------|------|
 | [Dev Browser](https://github.com/SawyerHood/dev-browser) | 에이전트를 위한 웹 브라우저 기능 |
+| [Vectorize MCP Worker](https://github.com/dannwaneri/vectorize-mcp-worker) | 프로덕션 RAG를 위한 엣지 네이티브 MCP 서버 패턴 |
+| [Agent Manager](https://github.com/fractalmind-ai/agent-manager-skill) | tmux를 통해 로컬 CLI AI 에이전트 관리 (시작/중지/모니터링/할당 + cron 일정) |
+| [HOL Claude Skills](https://github.com/hashgraph-online/hol-claude-skills) | Registry Broker를 통한 AI 에이전트 검색 - /hol-search, /hol-resolve, /hol-chat |
 | [Sheets CLI](https://github.com/gmickel/sheets-cli) | Google Sheets CLI 자동화 |
 | [Notification Skill](https://github.com/caopulan/Notification-Skill) | 에이전트 워크플로우용 메시지 알림 전송 |
 | [Spotify Skill](https://github.com/fabioc-aloha/spotify-skill) | Spotify API 통합 |
+
+#### 협업 및 프로젝트 관리
+
+| 스킬 | 설명 |
+|------|------|
+| [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace) | git 작업 및 저장소 상호 작용 자동화 |
+| [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace) | 코드 구현 계획 평가 |
+| [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace) | 실패하는 테스트 감지 및 수정 제안 |
 
 #### 보안 및 시스템
 
 | 스킬 | 설명 |
 |------|------|
+| [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace) | 디지털 포렌식 분석 및 조사 |
 | [Threat Hunting](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) | Sigma 탐지 규칙을 사용한 위협 사냥 |
+
+#### 고급 및 연구
+
+| 스킬 | 설명 |
+|------|------|
+| [Context Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) | 컨텍스트 엔지니어링 기술 |
+| [Pomodoro System Skill](https://github.com/jakedahn/pomodoro) | 시스템 스킬 패턴 (기억하고 개선하는 스킬) |
+| [Mind Cloning](https://github.com/yzfly/Mind-Cloning-Engineering) | LLM 스킬을 이용한 마인드 클로닝 |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The following platforms have documented support for Agent Skills:
 | GitHub Copilot | [docs.github.com](https://docs.github.com/copilot/concepts/agents/about-agent-skills) |
 | VS Code | [code.visualstudio.com](https://code.visualstudio.com/docs/copilot/customization/agent-skills) |
 | Antigravity | [antigravity.google](https://antigravity.google/docs/skills) |
+| Gemini CLI | [geminicli.com](https://geminicli.com/docs/cli/skills/) |
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -57,6 +57,8 @@
 | Codex (OpenAI) | [developers.openai.com](https://developers.openai.com/codex/skills) |
 | GitHub Copilot | [docs.github.com](https://docs.github.com/copilot/concepts/agents/about-agent-skills) |
 | VS Code | [code.visualstudio.com](https://code.visualstudio.com/docs/copilot/customization/agent-skills) |
+| Antigravity | [antigravity.google](https://antigravity.google/docs/skills) |
+| Gemini CLI | [geminicli.com](https://geminicli.com/docs/cli/skills/) |
 
 ---
 
@@ -108,6 +110,15 @@ Codex 支持不同范围的技能：
 | [huggingface/skills](https://github.com/huggingface/skills) | HuggingFace 技能（兼容 Claude、Codex、Gemini）|
 | [skillcreatorai/Ai-Agent-Skills](https://github.com/skillcreatorai/Ai-Agent-Skills) | SkillCreator.ai 集合，附 CLI 安装程序 |
 | [karanb192/awesome-claude-skills](https://github.com/karanb192/awesome-claude-skills) | 50+ 经过验证的 Claude Code 和 Claude.ai 技能 |
+| [shajith003/awesome-claude-skills](https://github.com/shajith003/awesome-claude-skills) | 专门能力的技能 |
+| [GuDaStudio/skills](https://github.com/GuDaStudio/skills) | 多代理协作技能 |
+| [DougTrajano/pydantic-ai-skills](https://github.com/DougTrajano/pydantic-ai-skills) | Pydantic AI 集成 |
+| [OmidZamani/dspy-skills](https://github.com/OmidZamani/dspy-skills) | DSPy 框架技能 |
+| [hikanner/agent-skills](https://github.com/hikanner/agent-skills) | 精选 Claude 代理技能集合 |
+| [gradion-ai/freeact-skills](https://github.com/gradion-ai/freeact-skills) | Freeact 代理库技能 |
+| [gotalab/skillport](https://github.com/gotalab/skillport) | 通过 CLI 或 MCP 分发技能 |
+| [mhattingpete/claude-skills-marketplace](https://github.com/mhattingpete/claude-skills-marketplace) | Git、代码审查和测试技能 |
+| [kukapay/crypto-skills](https://github.com/kukapay/crypto-skills) | 加密货币、web3 和区块链技能。 |
 
 #### 文档处理
 
@@ -123,6 +134,11 @@ Codex 支持不同范围的技能：
 | [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) | D3 图表和交互式数据可视化 |
 | [Playwright Automation](https://github.com/lackeyjb/playwright-skill) | 测试网页应用的浏览器自动化 |
 | [Specrate](https://github.com/rickygao/specrate) | 以结构化工作流管理规格（spec）与变更 |
+| [iOS Simulator](https://github.com/conorluddy/ios-simulator-skill) | 与 iOS 模拟器交互以进行测试 |
+| [Swift Concurrency Migration](https://github.com/kylehughes/the-unofficial-swift-concurrency-migration-skill) | Swift 并发迁移指南 |
+| [Obsidian Plugin](https://github.com/gapmiss/obsidian-plugin-skill) | Obsidian.md 插件开发 |
+| [Stream Coding](https://github.com/frmoretto/stream-coding) | 流式编码方法论 |
+| [SwiftUI Skills](https://github.com/ameyalambat128/swiftui-skills) | 从 Xcode 提取的 Apple 编写的 SwiftUI 和平台指南 |
 
 #### 数据和分析
 
@@ -135,15 +151,35 @@ Codex 支持不同范围的技能：
 | 技能 | 描述 |
 |------|------|
 | [Dev Browser](https://github.com/SawyerHood/dev-browser) | 代理的网页浏览器功能 |
+| [Vectorize MCP Worker](https://github.com/dannwaneri/vectorize-mcp-worker) | 用于生产 RAG 的边缘原生 MCP 服务器模式 |
+| [Agent Manager](https://github.com/fractalmind-ai/agent-manager-skill) | 通过 tmux 管理本地 CLI AI 代理（启动/停止/监控/分配 + cron 调度） |
+| [HOL Claude Skills](https://github.com/hashgraph-online/hol-claude-skills) | 通过 Registry Broker 发现 AI 代理 - /hol-search, /hol-resolve, /hol-chat |
 | [Sheets CLI](https://github.com/gmickel/sheets-cli) | Google Sheets CLI 自动化 |
 | [Notification Skill](https://github.com/caopulan/Notification-Skill) | 为代理工作流发送消息通知 |
 | [Spotify Skill](https://github.com/fabioc-aloha/spotify-skill) | Spotify API 集成 |
+
+#### 协作与项目管理
+
+| 技能 | 描述 |
+|------|------|
+| [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace) | 自动化 git 操作和仓库交互 |
+| [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace) | 评估代码实施计划 |
+| [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace) | 检测失败的测试并提出修复建议 |
 
 #### 安全和系统
 
 | 技能 | 描述 |
 |------|------|
+| [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace) | 数字取证分析和调查 |
 | [Threat Hunting](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) | 使用 Sigma 检测规则进行威胁狩猎 |
+
+#### 高级与研究
+
+| 技能 | 描述 |
+|------|------|
+| [Context Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) | 上下文工程技术 |
+| [Pomodoro System Skill](https://github.com/jakedahn/pomodoro) | 系统技能模式（记忆和改进的技能） |
+| [Mind Cloning](https://github.com/yzfly/Mind-Cloning-Engineering) | 通过 LLM 技能进行思维克隆 |
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -57,6 +57,8 @@
 | Codex (OpenAI) | [developers.openai.com](https://developers.openai.com/codex/skills) |
 | GitHub Copilot | [docs.github.com](https://docs.github.com/copilot/concepts/agents/about-agent-skills) |
 | VS Code | [code.visualstudio.com](https://code.visualstudio.com/docs/copilot/customization/agent-skills) |
+| Antigravity | [antigravity.google](https://antigravity.google/docs/skills) |
+| Gemini CLI | [geminicli.com](https://geminicli.com/docs/cli/skills/) |
 
 ---
 
@@ -108,6 +110,15 @@ Codex 支援不同範圍的技能：
 | [huggingface/skills](https://github.com/huggingface/skills) | HuggingFace 技能（相容 Claude、Codex、Gemini）|
 | [skillcreatorai/Ai-Agent-Skills](https://github.com/skillcreatorai/Ai-Agent-Skills) | SkillCreator.ai 集合，附 CLI 安裝程式 |
 | [karanb192/awesome-claude-skills](https://github.com/karanb192/awesome-claude-skills) | 50+ 經過驗證的 Claude Code 和 Claude.ai 技能 |
+| [shajith003/awesome-claude-skills](https://github.com/shajith003/awesome-claude-skills) | 專門能力的技能 |
+| [GuDaStudio/skills](https://github.com/GuDaStudio/skills) | 多代理協作技能 |
+| [DougTrajano/pydantic-ai-skills](https://github.com/DougTrajano/pydantic-ai-skills) | Pydantic AI 整合 |
+| [OmidZamani/dspy-skills](https://github.com/OmidZamani/dspy-skills) | DSPy 框架技能 |
+| [hikanner/agent-skills](https://github.com/hikanner/agent-skills) | 精選 Claude 代理技能集合 |
+| [gradion-ai/freeact-skills](https://github.com/gradion-ai/freeact-skills) | Freeact 代理庫技能 |
+| [gotalab/skillport](https://github.com/gotalab/skillport) | 透過 CLI 或 MCP 分發技能 |
+| [mhattingpete/claude-skills-marketplace](https://github.com/mhattingpete/claude-skills-marketplace) | Git、程式碼審查和測試技能 |
+| [kukapay/crypto-skills](https://github.com/kukapay/crypto-skills) | 加密貨幣、web3 和區塊鏈技能。 |
 
 #### 文件處理
 
@@ -123,6 +134,11 @@ Codex 支援不同範圍的技能：
 | [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) | D3 圖表和互動式資料視覺化 |
 | [Playwright Automation](https://github.com/lackeyjb/playwright-skill) | 測試網頁應用的瀏覽器自動化 |
 | [Specrate](https://github.com/rickygao/specrate) | 以結構化工作流程管理規格（spec）與變更 |
+| [iOS Simulator](https://github.com/conorluddy/ios-simulator-skill) | 與 iOS 模擬器互動以進行測試 |
+| [Swift Concurrency Migration](https://github.com/kylehughes/the-unofficial-swift-concurrency-migration-skill) | Swift 並發遷移指南 |
+| [Obsidian Plugin](https://github.com/gapmiss/obsidian-plugin-skill) | Obsidian.md 外掛程式開發 |
+| [Stream Coding](https://github.com/frmoretto/stream-coding) | 流式編碼方法論 |
+| [SwiftUI Skills](https://github.com/ameyalambat128/swiftui-skills) | 從 Xcode 提取的 Apple 編寫的 SwiftUI 和平台指南 |
 
 #### 資料和分析
 
@@ -135,15 +151,35 @@ Codex 支援不同範圍的技能：
 | 技能 | 描述 |
 |------|------|
 | [Dev Browser](https://github.com/SawyerHood/dev-browser) | 代理的網頁瀏覽器功能 |
+| [Vectorize MCP Worker](https://github.com/dannwaneri/vectorize-mcp-worker) | 用於生產 RAG 的邊緣原生 MCP 伺服器模式 |
+| [Agent Manager](https://github.com/fractalmind-ai/agent-manager-skill) | 透過 tmux 管理本地 CLI AI 代理（啟動/停止/監控/分配 + cron 排程） |
+| [HOL Claude Skills](https://github.com/hashgraph-online/hol-claude-skills) | 透過 Registry Broker 發現 AI 代理 - /hol-search, /hol-resolve, /hol-chat |
 | [Sheets CLI](https://github.com/gmickel/sheets-cli) | Google Sheets CLI 自動化 |
 | [Notification Skill](https://github.com/caopulan/Notification-Skill) | 為代理工作流程發送訊息通知 |
 | [Spotify Skill](https://github.com/fabioc-aloha/spotify-skill) | Spotify API 整合 |
+
+#### 協作與專案管理
+
+| 技能 | 描述 |
+|------|------|
+| [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace) | 自動化 git 操作和倉庫互動 |
+| [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace) | 評估程式碼實施計畫 |
+| [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace) | 檢測失敗的測試並提出修復建議 |
 
 #### 安全和系統
 
 | 技能 | 描述 |
 |------|------|
+| [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace) | 數位鑑識分析和調查 |
 | [Threat Hunting](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) | 使用 Sigma 偵測規則進行威脅狩獵 |
+
+#### 進階與研究
+
+| 技能 | 描述 |
+|------|------|
+| [Context Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) | 上下文工程技術 |
+| [Pomodoro System Skill](https://github.com/jakedahn/pomodoro) | 系統技能模式（記憶和改進的技能） |
+| [Mind Cloning](https://github.com/yzfly/Mind-Cloning-Engineering) | 透過 LLM 技能進行思維複製 |
 
 ---
 


### PR DESCRIPTION
## Overview
This Pull Request adds the **Gemini CLI** to the list of compatible agents and synchronizes the translated README files with the latest content from the English `README.md`.

## Changes
- **Added Gemini CLI**: Included "Gemini CLI" in the "Compatible Agents" table across all README files (`README.md`, `README.es.md`, `README.ja.md`, `README.ko.md`, `README.zh-CN.md`, `README.zh-TW.md`).
- **Added Antigravity**: Restored the missing "Antigravity" entry in all translated README files to match the English version.
- **Synchronized Community Skills**: Updated the "Community Skills" sections in all localized READMEs. This includes:
  - Adding ~9 missing Skill Collections.
  - Adding missing Development, Integration, and Automation tools.
  - Adding the "Collaboration & Project Management" and "Advanced & Research" sections.
  - Translating all new descriptions into Spanish, Japanese, Korean, Simplified Chinese, and Traditional Chinese.

## Why
Ensures that all users, regardless of language, have access to the most up-to-date list of tools and community skills supported by the Agent Skills ecosystem.
