### PR TITLE
Add Tool Advisor to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Community-maintained skills and collections (verify before use):
 | [Obsidian Plugin](https://github.com/gapmiss/obsidian-plugin-skill) | Obsidian.md plugin development |
 | [Stream Coding](https://github.com/frmoretto/stream-coding) | Stream Coding methodology |
 | [SwiftUI Skills](https://github.com/ameyalambat128/swiftui-skills) | Apple-authored SwiftUI and platform guidance extracted from Xcode |
+| [Tool Advisor](https://github.com/dragon1086/claude-skills) | Analyzes prompts and recommends optimal tools, skills, agents, and orchestration patterns |
 
 #### Data & Analysis
 


### PR DESCRIPTION
## Summary

Adds [Tool Advisor](https://github.com/dragon1086/claude-skills) to the Community Skills → Development & Code Tools section.

**What it does:**
- Analyzes natural language prompts and recommends optimal tools, skills, agents, and orchestration patterns
- Suggests harness patterns (Ralph, RIPER, Spec) for complex long-running tasks
- Offers installation suggestions when needed tools are missing
- Provides copy-paste ready commands via "Quick Action" table

**Features:**
- 6-Phase analysis process
- Multi-language README (EN, KO, JA, ZH, ES, PT, RU, FR, DE)
- One-line install: `curl -fsSL https://raw.githubusercontent.com/dragon1086/claude-skills/main/install.sh | bash`

## Checklist

- [x] Skill exists and is functional
- [x] Follows table format: `| [Name](URL) | Description |`
- [x] Added to appropriate section (Development & Code Tools)
- [x] Description is concise