### PR TITLE
Add AgentFund skill to collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Community-maintained skills and collections (verify before use):
 | [gotalab/skillport](https://github.com/gotalab/skillport) | Skills distribution via CLI or MCP |
 | [mhattingpete/claude-skills-marketplace](https://github.com/mhattingpete/claude-skills-marketplace) | Git, code review, and testing skills |
 | [kukapay/crypto-skills](https://github.com/kukapay/crypto-skills) |  cryptocurrency, web3 and blockchain skills. |
+| [RioBot-Grind/agentfund-skill](https://github.com/RioBot-Grind/agentfund-skill) | Crowdfunding for AI agents on Base chain - milestone escrow |
 
 #### Document Processing
 


### PR DESCRIPTION
Adding AgentFund - crowdfunding platform for AI agents on Base chain.

**What it does:**
- Create fundraising proposals with milestones
- Track funded projects
- Request milestone payments

**Links:**
- Skill: https://github.com/RioBot-Grind/agentfund-skill
- MCP Server: https://github.com/RioBot-Grind/agentfund-mcp