### PR TITLE
(chore): add Kiro to the skill list in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ The following platforms have documented support for Agent Skills:
 | GitHub Copilot | [docs.github.com](https://docs.github.com/copilot/concepts/agents/about-agent-skills) |
 | VS Code | [code.visualstudio.com](https://code.visualstudio.com/docs/copilot/customization/agent-skills) |
 | Antigravity | [antigravity.google](https://antigravity.google/docs/skills) |
+| Kiro | [kiro.dev](https://kiro.dev/docs/skills/) |
 
 ---
 


### PR DESCRIPTION
Kiro announced support for Agent Skills for both the IDE and the cli.