### PR TITLE
Add sanjay3290/ai-skills to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Community-maintained skills and collections (verify before use):
 | [gotalab/skillport](https://github.com/gotalab/skillport) | Skills distribution via CLI or MCP |
 | [mhattingpete/claude-skills-marketplace](https://github.com/mhattingpete/claude-skills-marketplace) | Git, code review, and testing skills |
 | [kukapay/crypto-skills](https://github.com/kukapay/crypto-skills) |  cryptocurrency, web3 and blockchain skills. |
+| [sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills) | Google Workspace (Gmail, Chat, Calendar, Docs, Drive, Sheets, Slides), AI delegation (Jules, Manus, Deep Research), and database skills |
 
 #### Document Processing
 


### PR DESCRIPTION
## Summary
- Adds [sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills) to the Skill Collections table

## What's in the collection
- **Google Workspace skills**: Gmail, Google Chat, Google Calendar, Google Docs, Google Drive, Google Sheets, Google Slides
- **AI delegation skills**: Jules, Manus, Deep Research, Imagen
- **Knowledge & data skills**: NotebookLM, Outline, Postgres

All skills follow the standard `SKILL.md` pattern and are compatible with Claude Code.