### PR TITLE
Add kaggle-skill to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Community-maintained skills and collections (verify before use):
 | Skill | Description |
 |-------|-------------|
 | [CSV Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) | Analyze CSV files and generate insights with visualizations |
+| [Kaggle Skill](https://github.com/shepsci/kaggle-skill) | Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection |
 
 #### Integration & Automation
 


### PR DESCRIPTION
adds SKILL for accessing kaggle.com data science resources, community, and competitions