### PR TITLE
Add Agent OS Governance skill to Security section

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Community-maintained skills and collections (verify before use):
 |-------|-------------|
 | [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace) | Digital forensics analysis and investigation |
 | [Threat Hunting](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) | Hunt for threats using Sigma detection rules |
+| [Agent OS Governance](https://github.com/imran-siddique/agent-os) | Kernel-level governance for AI agents — deterministic policy enforcement, compliance checking, audit logging |
 
 #### Advanced & Research
 


### PR DESCRIPTION
Adds [Agent OS Governance](https://github.com/imran-siddique/agent-os) to the Security section — kernel-level governance for AI agents with deterministic policy enforcement, compliance checking, and audit logging.

**Integrations:** Merged into [LlamaIndex](https://github.com/run-llama/llama_index) (47k stars) and [Microsoft agent-lightning](https://github.com/microsoft/agent-lightning) (14k stars).

> Re-opened from #30 which was accidentally closed during a fork cleanup.