### PR TITLE
Add skill collection: chadboyda/agent-gtm-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Community-maintained skills and collections (verify before use):
 | [gotalab/skillport](https://github.com/gotalab/skillport) | Skills distribution via CLI or MCP |
 | [mhattingpete/claude-skills-marketplace](https://github.com/mhattingpete/claude-skills-marketplace) | Git, code review, and testing skills |
 | [kukapay/crypto-skills](https://github.com/kukapay/crypto-skills) |  cryptocurrency, web3 and blockchain skills. |
+| [chadboyda/agent-gtm-skills](https://github.com/chadboyda/agent-gtm-skills) | 18 go-to-market skills: pricing, outbound, SEO, ads, retention, and ops |
 
 #### Document Processing
 


### PR DESCRIPTION
Adds [agent-gtm-skills](https://github.com/chadboyda/agent-gtm-skills) to the Skill Collections table.

**Entry added:**
```
| [chadboyda/agent-gtm-skills](https://github.com/chadboyda/agent-gtm-skills) | 18 go-to-market skills: pricing, outbound, SEO, ads, retention, and ops |
```

**About the collection:**
18 skill files (9,800+ lines total) covering the full go-to-market surface. Each skill is a 300-900 line playbook with frameworks, benchmarks (2025-2026), and decision matrices across 6 layers: strategy, outbound, inbound, paid, retention, and operations.

- Public repo with README and SKILL.md per skill
- MIT licensed
- Landing page: [agentgtmskills.com](https://agentgtmskills.com)
- Compatible with Claude Code, Codex, Cursor, Windsurf, GitHub Copilot, Gemini CLI, and more