### PR TITLE
Add agentskill.sh to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Community-maintained skills and collections (verify before use):
 | [openai/skills](https://github.com/openai/skills) | Official OpenAI Codex skills catalog |
 | [huggingface/skills](https://github.com/huggingface/skills) | HuggingFace skills (compatible with Claude, Codex, Gemini) |
 | [skillcreatorai/Ai-Agent-Skills](https://github.com/skillcreatorai/Ai-Agent-Skills) | SkillCreator.ai collection with CLI installer |
+| [agentskill.sh](https://agentskill.sh) | 44k+ skills directory with security scanning and `/learn` installer |
 | [karanb192/awesome-claude-skills](https://github.com/karanb192/awesome-claude-skills) | 50+ verified skills for Claude Code and Claude.ai |
 | [shajith003/awesome-claude-skills](https://github.com/shajith003/awesome-claude-skills) | Skills for specialized capabilities |
 | [GuDaStudio/skills](https://github.com/GuDaStudio/skills) | Multi-agent collaboration skills |


### PR DESCRIPTION
Adds [agentskill.sh](https://agentskill.sh) to the Skill Collections table.

**What it is:**
- 44k+ skills directory with security scanning
- `/learn` installer for one-command installation
- Works with Claude Code, Codex, Cursor, and more

[Browse skills](https://agentskill.sh) | [Security dashboard](https://agentskill.sh/security)