### PR TITLE
Add PM Skills to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Community-maintained skills and collections (verify before use):
 | [gotalab/skillport](https://github.com/gotalab/skillport) | Skills distribution via CLI or MCP |
 | [mhattingpete/claude-skills-marketplace](https://github.com/mhattingpete/claude-skills-marketplace) | Git, code review, and testing skills |
 | [kukapay/crypto-skills](https://github.com/kukapay/crypto-skills) |  cryptocurrency, web3 and blockchain skills. |
+| [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 product management skills covering discovery, definition, delivery, and optimization |
 
 #### Document Processing
 


### PR DESCRIPTION
Adds [pm-skills](https://github.com/product-on-purpose/pm-skills) to the Skill Collections table.

**What it is:** An open-source library of 24 product management agent skills organized across six Triple Diamond phases (Discover, Define, Develop, Deliver, Measure, Iterate). Follows the [agentskills.io specification](https://agentskills.io/specification). Apache 2.0 licensed.

**Why it fits:** Product management is a domain not currently covered in the Skill Collections. Each skill ships with SKILL.md, TEMPLATE.md, and EXAMPLE.md — ready for Claude Code, Codex, Cursor, and other agent platforms.

Happy to adjust placement or wording to fit the list's conventions.