### PR TITLE
Sync translations, update FAQ, add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,79 @@
+# Contributing to Awesome Agent Skills
+
+Thank you for your interest in contributing! This document provides guidelines to ensure consistency and quality across the repository.
+
+## Adding a New Skill or Collection
+
+### Entry Format
+
+All entries must be added as **table rows** in the correct section of `README.md`. Use this format:
+
+```markdown
+| [Skill Name](https://github.com/owner/repo) | Short, neutral description of what the skill does |
+```
+
+### Quality Checklist
+
+Before submitting a PR:
+
+- [ ] The repository or link is **public and accessible** (no 404s)
+- [ ] The entry is placed in the **correct section** (Skill Collections, Dev Tools, Integration, etc.)
+- [ ] The description is **one line**, neutral, and factual — no promotional language
+- [ ] The entry uses **table row format** (`| link | description |`), not bullet points
+- [ ] You have verified the skill/tool **actually works**
+- [ ] No duplicate entries exist in the list
+
+### Section Ordering
+
+Entries within each section are organized in the order they were added. Add new entries at the **end** of the relevant section table.
+
+The main sections are:
+
+1. **Skill Collections** — repositories containing multiple skills
+2. **Document Processing** — document conversion and manipulation
+3. **Development & Code Tools** — coding, testing, and dev workflows
+4. **Data & Analysis** — data processing and analytics
+5. **Integration & Automation** — external service connections and automation
+6. **Collaboration & Project Management** — git workflows and team tools
+7. **Security & Systems** — security analysis and system management
+8. **Advanced & Research** — experimental and research-oriented skills
+
+## Translation Guidelines
+
+This repository is maintained in 6 languages:
+
+| File | Language |
+|------|----------|
+| `README.md` | English (source of truth) |
+| `README.es.md` | Spanish |
+| `README.ja.md` | Japanese |
+| `README.ko.md` | Korean |
+| `README.zh-CN.md` | Simplified Chinese |
+| `README.zh-TW.md` | Traditional Chinese |
+
+When making changes:
+
+- **English-only PRs are fine** — maintainers will sync translations
+- If you update a translated README, ensure the change matches the English version
+- **Do not translate**: repository names, URLs, code blocks, CLI commands, or technical identifiers
+- **Do translate**: section headers, descriptions, and explanatory text
+- Keep the same structure and section ordering across all files
+
+## PR Guidelines
+
+- **One logical change per PR** — don't bundle unrelated additions
+- **Title format**: `Add [skill-name] to [section]` or `docs: [description]`
+- Ensure your PR doesn't introduce merge conflicts with `main`
+- If adding to Skill Collections, only `README.md` needs to be updated (translations will be synced)
+
+## What Will Get Your PR Closed
+
+- Linked repository returns a **404** (deleted or private)
+- Entry placed in the **wrong section** (e.g., in Table of Contents or "How It Works")
+- **Promotional or marketing language** in the description
+- **Duplicate** of an existing entry
+- **Broken formatting** (not a valid table row)
+
+## Questions?
+
+Open an issue if you're unsure where an entry belongs or need help with formatting.

--- a/README.es.md
+++ b/README.es.md
@@ -124,6 +124,8 @@ Habilidades y colecciones mantenidas por la comunidad (verificar antes de usar):
 | [kukapay/crypto-skills](https://github.com/kukapay/crypto-skills) | Habilidades de criptomonedas, Web3 y blockchain |
 | [chadboyda/agent-gtm-skills](https://github.com/chadboyda/agent-gtm-skills) | 18 habilidades go-to-market: precios, outbound, SEO, anuncios, retención y operaciones |
 | [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 habilidades de gestión de producto: descubrimiento, definición, entrega y optimización |
+| [sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills) | Google Workspace (Gmail, Chat, Calendar, Docs, Drive, Sheets, Slides), delegación de IA (Jules, Manus, Deep Research) y habilidades de bases de datos |
+| [RioBot-Grind/agentfund-skill](https://github.com/RioBot-Grind/agentfund-skill) | Crowdfunding para agentes de IA en cadena Base — custodia por hitos |
 
 #### Procesamiento de Documentos
 
@@ -178,14 +180,6 @@ Habilidades y colecciones mantenidas por la comunidad (verificar antes de usar):
 | [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace) | Evaluar planes de implementación de código |
 | [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace) | Detectar pruebas fallidas y proponer correcciones |
 
-#### Colaboración y Gestión de Proyectos
-
-| Habilidad | Descripción |
-|------|------|
-| [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace) | Automatizar operaciones git e interacciones con el repositorio |
-| [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace) | Evaluar planes de implementación de código |
-| [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace) | Detectar pruebas fallidas y proponer correcciones |
-
 #### Seguridad y Sistemas
 
 | Habilidad | Descripción |
@@ -201,14 +195,6 @@ Habilidades y colecciones mantenidas por la comunidad (verificar antes de usar):
 
 | Habilidad | Descripción |
 |-----------|-------------|
-| [Context Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) | Técnicas de ingeniería de contexto |
-| [Pomodoro System Skill](https://github.com/jakedahn/pomodoro) | Patrón de Habilidad del Sistema (habilidades que recuerdan y mejoran) |
-| [Mind Cloning](https://github.com/yzfly/Mind-Cloning-Engineering) | Clonación mental con habilidades LLM |
-
-#### Avanzado e Investigación
-
-| Habilidad | Descripción |
-|------|------|
 | [Context Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) | Técnicas de ingeniería de contexto |
 | [Pomodoro System Skill](https://github.com/jakedahn/pomodoro) | Patrón de Habilidad del Sistema (habilidades que recuerdan y mejoran) |
 | [Mind Cloning](https://github.com/yzfly/Mind-Cloning-Engineering) | Clonación mental con habilidades LLM |
@@ -259,6 +245,37 @@ cp -r skill-name ~/.claude/skills/
 
 La habilidad se carga automáticamente y se activa cuando es relevante.
 
+### Usando Habilidades en Codex
+
+**Crear una habilidad:**
+
+Usa la habilidad integrada `$skill-creator` en Codex. Describe lo que quieres que haga tu habilidad, y Codex la creará por ti.
+
+Si instalas `$create-plan` (experimental) con `$skill-installer create-plan`, Codex creará un plan antes de escribir archivos.
+
+También puedes crear una habilidad manualmente creando una carpeta con un archivo `SKILL.md`:
+
+````markdown
+---
+name: skill-name
+description: Descripción que ayuda a Codex a seleccionar la habilidad
+metadata:
+  short-description: Descripción opcional para el usuario
+---
+
+Instrucciones de la habilidad para que el agente Codex las siga al usar esta habilidad.
+````
+
+**Instalar nuevas habilidades:**
+
+Descarga habilidades desde GitHub usando la habilidad `$skill-installer`:
+
+```bash
+$skill-installer linear
+```
+
+También puedes indicar al instalador que descargue habilidades de otros repositorios. Después de instalar una habilidad, reinicia Codex para cargar las nuevas habilidades.
+
 ### Usando Habilidades en VS Code
 
 Las habilidades se almacenan en directorios con un archivo `SKILL.md`. VS Code soporta dos ubicaciones:
@@ -281,6 +298,62 @@ description: Descripción de lo que hace la habilidad y cuándo usarla
 # Instrucciones de la Habilidad
 
 Tus instrucciones detalladas, pautas y ejemplos van aquí...
+```
+
+### Usando Habilidades en Copilot CLI
+
+**Agregar habilidades a tu repositorio:**
+
+1. Crea un directorio `.github/skills` (las habilidades en `.claude/skills` también son compatibles)
+2. Crea un subdirectorio para tu habilidad (ej. `.github/skills/webapp-testing`)
+3. Crea un archivo `SKILL.md` con las instrucciones de tu habilidad
+
+**Estructura de SKILL.md:**
+
+- `name` (requerido): Un identificador único en minúsculas usando guiones para espacios
+- `description` (requerido): Qué hace la habilidad y cuándo Copilot debe usarla
+- `license` (opcional): Licencia que se aplica a esta habilidad
+- Cuerpo en Markdown con instrucciones, ejemplos y pautas
+
+**Ejemplo de SKILL.md:**
+
+````markdown
+---
+name: github-actions-failure-debugging
+description: Guía para depurar flujos de trabajo fallidos de GitHub Actions.
+---
+
+Para depurar flujos de trabajo fallidos de GitHub Actions:
+
+1. Usa `list_workflow_runs` para buscar ejecuciones recientes del flujo de trabajo
+2. Usa `summarize_job_log_failures` para obtener un resumen de IA de los trabajos fallidos
+3. Usa `get_job_logs` para registros detallados de fallas si es necesario
+4. Intenta reproducir la falla en tu entorno
+5. Corrige la compilación fallida
+````
+
+Cuando realiza tareas, Copilot decide cuándo usar habilidades basándose en tu prompt y la descripción de la habilidad. El archivo `SKILL.md` se inyecta en el contexto del agente.
+
+### Usando Servidores MCP (Claude Desktop)
+
+Edita tu archivo de configuración:
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Ejemplo de configuración:
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/Users/username/Desktop"
+      ]
+    }
+  }
+}
 ```
 
 ---
@@ -325,6 +398,29 @@ Descripción detallada del propósito de la habilidad.
 [Ejemplos del mundo real]
 ```
 
+### Ejemplo de Servidor MCP (Python)
+
+Para habilidades que necesitan conectarse a fuentes de datos externas, puedes crear un servidor MCP:
+
+```bash
+pip install fastmcp
+```
+
+server.py:
+```python
+from fastmcp import FastMCP
+
+mcp = FastMCP("My Server")
+
+@mcp.tool()
+def hello_world(name: str = "World") -> str:
+    """A simple tool that says hello."""
+    return f"Hello, {name}!"
+
+if __name__ == "__main__":
+    mcp.run()
+```
+
 ---
 
 ## Recursos de la Comunidad
@@ -334,6 +430,10 @@ Descripción detallada del propósito de la habilidad.
 - [Wikipedia](https://python.langchain.com/docs/integrations/tools/wikipedia/) - Obtener resúmenes de Wikipedia
 - [Python REPL](https://python.langchain.com/docs/integrations/tools/python/) - Ejecutar código Python
 - [Custom Tools Guide](https://python.langchain.com/docs/how_to/custom_tools/) - Cómo usar el decorador `@tool`
+
+### Artículos e Investigación
+- [I found 50 companies accidentally breaking HIPAA with ChatGPT](https://dev.to/dannwaneri/i-found-50-companies-accidentally-breaking-hipaa-with-chatgpt-1olc) - Análisis de riesgos de privacidad en IA
+- [I built a Production RAG System for $5/month](https://dev.to/dannwaneri/i-built-a-production-rag-system-for-5month-most-alternatives-cost-100-200-21hj) - Guía de optimización de costos para arquitecturas RAG
 
 ---
 
@@ -355,23 +455,34 @@ Hacen cosas diferentes y funcionan muy bien juntas:
 
 ### ¿Qué herramientas de IA soportan Agent Skills?
 
-Actualmente soportadas: **Claude** (Claude.ai y Claude Code), **GitHub Copilot**, **VS Code**, y otras. La lista está creciendo a medida que más herramientas adoptan el estándar.
+Actualmente soportadas: **Claude** (Claude.ai y Claude Code), **GitHub Copilot**, **VS Code**, **Codex** (OpenAI), **Antigravity** (Google), **Gemini CLI** y **Kiro**. La lista está creciendo a medida que más herramientas adoptan el estándar.
 
 ### ¿Las Agent Skills ejecutan código?
 
 No. Las habilidades son solo instrucciones de texto, la IA las lee y las sigue como una receta. Si necesitas ejecutar código real, usarías algo como servidores MCP junto con las habilidades.
 
+### ¿Cómo creo mi primera Agent Skill?
+
+1. Crea un archivo `SKILL.md` con un nombre y una descripción en la parte superior
+2. Escribe instrucciones claras paso a paso en el archivo
+3. Colócalo en tu carpeta `.github/skills/` o `.claude/skills/`
+4. ¡Pruébalo!
+
+Guía completa: [Cómo crear habilidades personalizadas](https://support.claude.com/en/articles/12512198-creating-custom-skills)
+
 ---
 
 ## Contribuyendo
 
-Este repositorio sigue el modelo de desarrollo abierto de Agent Skills. Las contribuciones son bienvenidas desde el ecosistema más amplio. Al contribuir:
+Las contribuciones son bienvenidas. Consulta **[CONTRIBUTING.md](CONTRIBUTING.md)** para las directrices completas.
 
+Resumen rápido:
 - Sigue la estructura de la plantilla de habilidades
 - Proporciona instrucciones claras y accionables
 - Incluye ejemplos funcionales donde sea apropiado
 - Documenta las compensaciones y problemas potenciales
 - Mantén SKILL.md por debajo de 500 líneas para un rendimiento óptimo
+- Verifica que las habilidades existan realmente antes de agregarlas
 
 ---
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -124,6 +124,8 @@ Codexは異なるスコープのスキルをサポートしています：
 | [kukapay/crypto-skills](https://github.com/kukapay/crypto-skills) | 暗号通貨、Web3、ブロックチェーンスキル |
 | [chadboyda/agent-gtm-skills](https://github.com/chadboyda/agent-gtm-skills) | 18のGo-To-Marketスキル：価格設定、アウトバウンド、SEO、広告、リテンション、オペレーション |
 | [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) | 24のプロダクトマネジメントスキル：発見、定義、デリバリー、最適化をカバー |
+| [sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills) | Google Workspace（Gmail、Chat、Calendar、Docs、Drive、Sheets、Slides）、AI委任（Jules、Manus、Deep Research）、データベーススキル |
+| [RioBot-Grind/agentfund-skill](https://github.com/RioBot-Grind/agentfund-skill) | Baseチェーン上のAIエージェント向けクラウドファンディング — マイルストーンエスクロー |
 
 #### ドキュメント処理
 
@@ -178,14 +180,6 @@ Codexは異なるスコープのスキルをサポートしています：
 | [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace) | コード実装プランの評価 |
 | [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace) | 失敗テストの検出と修正案の提示 |
 
-#### コラボレーションとプロジェクト管理
-
-| スキル | 説明 |
-|------|------|
-| [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace) | git操作とリポジトリ対話を自動化 |
-| [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace) | コード実装計画を評価 |
-| [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace) | 失敗したテストを検出し、修正を提案 |
-
 #### セキュリティ・システム
 
 | スキル | 説明 |
@@ -201,14 +195,6 @@ Codexは異なるスコープのスキルをサポートしています：
 
 | スキル | 説明 |
 |--------|------|
-| [Context Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) | コンテキストエンジニアリング技術 |
-| [Pomodoro System Skill](https://github.com/jakedahn/pomodoro) | システムスキルパターン（記憶し改善するスキル） |
-| [Mind Cloning](https://github.com/yzfly/Mind-Cloning-Engineering) | LLMスキルによるマインドクローニング |
-
-#### 高度な研究
-
-| スキル | 説明 |
-|------|------|
 | [Context Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) | コンテキストエンジニアリング技術 |
 | [Pomodoro System Skill](https://github.com/jakedahn/pomodoro) | システムスキルパターン（記憶し改善するスキル） |
 | [Mind Cloning](https://github.com/yzfly/Mind-Cloning-Engineering) | LLMスキルによるマインドクローニング |
@@ -259,6 +245,37 @@ cp -r skill-name ~/.claude/skills/
 
 スキルは自動的にロードされ、必要なときにアクティブになります。
 
+### Codexでのスキルの使用
+
+**スキルの作成：**
+
+Codexの組み込み `$skill-creator` スキルを使用します。スキルに何をさせたいかを説明すると、Codexが自動的に作成します。
+
+`$skill-installer create-plan` で `$create-plan`（実験的）をインストールすると、Codexはファイルを書く前にプランを作成します。
+
+フォルダと `SKILL.md` ファイルを作成して手動でスキルを作ることもできます：
+
+````markdown
+---
+name: skill-name
+description: Codexがスキルを選択するのに役立つ説明
+metadata:
+  short-description: オプションのユーザー向け説明
+---
+
+このスキルを使用する際にCodexエージェントが従うスキルの指示。
+````
+
+**新しいスキルのインストール：**
+
+`$skill-installer` スキルを使用してGitHubからスキルをダウンロードします：
+
+```bash
+$skill-installer linear
+```
+
+インストーラーに他のリポジトリからスキルをダウンロードするよう指示することもできます。スキルをインストールした後、新しいスキルを読み込むためにCodexを再起動してください。
+
 ### VS Codeでのスキルの使用
 
 スキルは`SKILL.md`ファイルを含むディレクトリに保存されます。VS Codeは2つの場所をサポートしています：
@@ -281,6 +298,62 @@ description: スキルの機能と使用タイミングの説明
 # スキル指示書
 
 詳細な指示、ガイドライン、例などをここに記述します...
+```
+
+### Copilot CLIでのスキルの使用
+
+**リポジトリにスキルを追加する：**
+
+1. `.github/skills` ディレクトリを作成します（`.claude/skills` のスキルもサポートされています）
+2. スキル用のサブディレクトリを作成します（例：`.github/skills/webapp-testing`）
+3. スキルの指示を含む `SKILL.md` ファイルを作成します
+
+**SKILL.mdの構造：**
+
+- `name`（必須）：スペースの代わりにハイフンを使用した一意の小文字識別子
+- `description`（必須）：スキルの機能とCopilotがいつ使用すべきか
+- `license`（オプション）：このスキルに適用されるライセンス
+- 指示、例、ガイドラインを含むMarkdown本文
+
+**SKILL.mdの例：**
+
+````markdown
+---
+name: github-actions-failure-debugging
+description: 失敗したGitHub Actionsワークフローのデバッグガイド。
+---
+
+失敗したGitHub Actionsワークフローをデバッグするには：
+
+1. `list_workflow_runs` を使用して最近のワークフロー実行を検索
+2. `summarize_job_log_failures` を使用して失敗したジョブのAIサマリーを取得
+3. 必要に応じて `get_job_logs` で詳細な失敗ログを取得
+4. 環境で障害を再現してみる
+5. 失敗したビルドを修正する
+````
+
+タスクを実行する際、Copilotはプロンプトとスキルの説明に基づいてスキルを使用するタイミングを決定します。`SKILL.md` ファイルはエージェントのコンテキストに注入されます。
+
+### MCPサーバーの使用（Claude Desktop）
+
+設定ファイルを編集します：
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+設定例：
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/Users/username/Desktop"
+      ]
+    }
+  }
+}
 ```
 
 ---
@@ -325,6 +398,29 @@ description: このスキルが何をするか明確な説明。
 [実際の例]
 ```
 
+### MCPサーバーの例（Python）
+
+外部データソースに接続する必要があるスキルの場合、MCPサーバーを作成できます：
+
+```bash
+pip install fastmcp
+```
+
+server.py:
+```python
+from fastmcp import FastMCP
+
+mcp = FastMCP("My Server")
+
+@mcp.tool()
+def hello_world(name: str = "World") -> str:
+    """A simple tool that says hello."""
+    return f"Hello, {name}!"
+
+if __name__ == "__main__":
+    mcp.run()
+```
+
 ---
 
 ## コミュニティリソース
@@ -334,6 +430,10 @@ description: このスキルが何をするか明確な説明。
 - [Wikipedia](https://python.langchain.com/docs/integrations/tools/wikipedia/) - Wikipediaから要約を取得
 - [Python REPL](https://python.langchain.com/docs/integrations/tools/python/) - Pythonコードを実行
 - [Custom Tools Guide](https://python.langchain.com/docs/how_to/custom_tools/) - `@tool`デコレーターの使用方法
+
+### 記事・研究
+- [I found 50 companies accidentally breaking HIPAA with ChatGPT](https://dev.to/dannwaneri/i-found-50-companies-accidentally-breaking-hipaa-with-chatgpt-1olc) - AIにおけるプライバシーリスクの分析
+- [I built a Production RAG System for $5/month](https://dev.to/dannwaneri/i-built-a-production-rag-system-for-5month-most-alternatives-cost-100-200-21hj) - RAGアーキテクチャのコスト最適化ガイド
 
 ---
 
@@ -355,23 +455,34 @@ Agent Skillsは、AIアシスタントに特定のタスクを行う方法を教
 
 ### どのAIツールがAgent Skillsをサポートしていますか？
 
-現在サポートされているのは、**Claude**（Claude.aiおよびClaude Code）、**GitHub Copilot**、**VS Code**などです。標準を採用するツールが増えるにつれて、リストは拡大しています。
+現在サポートされているもの：**Claude**（Claude.aiとClaude Code）、**GitHub Copilot**、**VS Code**、**Codex**（OpenAI）、**Antigravity**（Google）、**Gemini CLI**、**Kiro**。より多くのツールがこの標準を採用するにつれ、リストは増え続けています。
 
 ### Agent Skillsはコードを実行しますか？
 
 いいえ。スキルは単なるテキスト指示であり、AIはレシピのようにそれを読んで従います。実際のコードを実行する必要がある場合は、スキルの並行してMCPサーバーなどを使用します。
 
+### 最初のAgent Skillはどうやって作りますか？
+
+1. `SKILL.md` ファイルを作成し、上部に名前と説明を記載します
+2. ファイルに明確なステップバイステップの指示を書きます
+3. `.github/skills/` または `.claude/skills/` フォルダに配置します
+4. テストしてみましょう！
+
+完全ガイド：[カスタムスキルの作成方法](https://support.claude.com/en/articles/12512198-creating-custom-skills)
+
 ---
 
-## 貢献
+## 貢献する
 
-このリポジトリはAgent Skillsのオープン開発モデルに従っています。より広いエコシステムからの貢献を歓迎します。貢献する際は：
+貢献を歓迎します。完全なガイドラインは **[CONTRIBUTING.md](CONTRIBUTING.md)** をご覧ください。
 
-- スキルテンプレートの構造に従う
-- 明確で実行可能な指示を提供する
-- 適切な場合は動作する例を含める
-- トレードオフや潜在的な問題を文書化する
-- 最適なパフォーマンスのためにSKILL.mdは500行以下に保つ
+クイックサマリー：
+- スキルテンプレートの構造に従ってください
+- 明確で実行可能な指示を提供してください
+- 適切な場合は動作する例を含めてください
+- トレードオフと潜在的な問題を文書化してください
+- 最適なパフォーマンスのためにSKILL.mdを500行以下に保ってください
+- 追加する前にスキルが実際に存在することを確認してください
 
 ---
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -124,6 +124,8 @@ Codex는 다양한 범위의 스킬을 지원합니다:
 | [kukapay/crypto-skills](https://github.com/kukapay/crypto-skills) | 암호화폐, Web3 및 블록체인 스킬 |
 | [chadboyda/agent-gtm-skills](https://github.com/chadboyda/agent-gtm-skills) | 18개 Go-to-Market 스킬: 가격, 아웃바운드, SEO, 광고, 리텐션, 운영 |
 | [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) | 24개 제품 관리 스킬: 발견, 정의, 전달, 최적화 포함 |
+| [sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills) | Google Workspace (Gmail, Chat, Calendar, Docs, Drive, Sheets, Slides), AI 위임 (Jules, Manus, Deep Research) 및 데이터베이스 스킬 |
+| [RioBot-Grind/agentfund-skill](https://github.com/RioBot-Grind/agentfund-skill) | Base 체인의 AI 에이전트용 크라우드펀딩 — 마일스톤 에스크로 |
 
 #### 문서 처리
 
@@ -178,14 +180,6 @@ Codex는 다양한 범위의 스킬을 지원합니다:
 | [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace) | 코드 구현 계획 평가 |
 | [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace) | 실패한 테스트 감지 및 수정 제안 |
 
-#### 협업 및 프로젝트 관리
-
-| 스킬 | 설명 |
-|------|------|
-| [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace) | git 작업 및 저장소 상호 작용 자동화 |
-| [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace) | 코드 구현 계획 평가 |
-| [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace) | 실패하는 테스트 감지 및 수정 제안 |
-
 #### 보안 및 시스템
 
 | 스킬 | 설명 |
@@ -196,14 +190,6 @@ Codex는 다양한 범위의 스킬을 지원합니다:
 | [Vincent Wallet](https://github.com/HeyVincent-ai/agent-skills/tree/main/wallet) | 에이전트용 보안 EVM 지갑 — 전송, 스왑, 트랜잭션 |
 | [Vincent Polymarket](https://github.com/HeyVincent-ai/agent-skills/tree/main/polymarket) | 에이전트용 Polymarket 예측 시장 거래 |
 | [Agent OS Governance](https://github.com/imran-siddique/agent-os) | AI 에이전트 커널 수준 거버넌스 — 결정적 정책 실행, 규정 준수 검사, 감사 로깅 |
-
-#### 고급 및 연구
-
-| 스킬 | 설명 |
-|------|------|
-| [Context Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) | 컨텍스트 엔지니어링 기술 |
-| [Pomodoro System Skill](https://github.com/jakedahn/pomodoro) | 시스템 스킬 패턴 (기억하고 개선하는 스킬) |
-| [Mind Cloning](https://github.com/yzfly/Mind-Cloning-Engineering) | LLM 스킬을 이용한 마인드 클로닝 |
 
 #### 고급 및 연구
 
@@ -259,6 +245,37 @@ cp -r skill-name ~/.claude/skills/
 
 스킬은 자동으로 로드되며 관련이 있을 때 활성화됩니다.
 
+### Codex에서 스킬 사용
+
+**스킬 만들기:**
+
+Codex의 내장 `$skill-creator` 스킬을 사용하세요. 스킬이 무엇을 하길 원하는지 설명하면 Codex가 자동으로 생성합니다.
+
+`$skill-installer create-plan`으로 `$create-plan`(실험적)을 설치하면, Codex가 파일을 작성하기 전에 계획을 생성합니다.
+
+폴더와 `SKILL.md` 파일을 만들어 수동으로 스킬을 생성할 수도 있습니다:
+
+````markdown
+---
+name: skill-name
+description: Codex가 스킬을 선택하는 데 도움이 되는 설명
+metadata:
+  short-description: 선택적 사용자 대상 설명
+---
+
+이 스킬을 사용할 때 Codex 에이전트가 따를 스킬 지침.
+````
+
+**새 스킬 설치:**
+
+`$skill-installer` 스킬을 사용하여 GitHub에서 스킬을 다운로드합니다:
+
+```bash
+$skill-installer linear
+```
+
+설치 프로그램에 다른 리포지토리에서 스킬을 다운로드하도록 지시할 수도 있습니다. 스킬을 설치한 후 새 스킬을 로드하려면 Codex를 다시 시작하세요.
+
 ### VS Code에서 스킬 사용하기
 
 스킬은 `SKILL.md` 파일이 포함된 디렉터리에 저장됩니다. VS Code는 두 위치를 지원합니다:
@@ -281,6 +298,64 @@ description: 스킬의 기능과 사용 시기에 대한 설명
 # 스킬 지침
 
 자세한 지침, 가이드라인 및 예제는 여기에...
+```
+
+4. 선택 사항으로 스킬 디렉터리에 스크립트, 예제 또는 기타 리소스를 추가합니다.
+
+### Copilot CLI에서 스킬 사용
+
+**리포지토리에 스킬 추가하기:**
+
+1. `.github/skills` 디렉토리를 만듭니다 (`.claude/skills`의 스킬도 지원됩니다)
+2. 스킬용 하위 디렉토리를 만듭니다 (예: `.github/skills/webapp-testing`)
+3. 스킬 지침이 포함된 `SKILL.md` 파일을 만듭니다
+
+**SKILL.md 구조:**
+
+- `name` (필수): 공백 대신 하이픈을 사용하는 고유한 소문자 식별자
+- `description` (필수): 스킬이 하는 일과 Copilot이 언제 사용해야 하는지
+- `license` (선택): 이 스킬에 적용되는 라이선스
+- 지침, 예제, 가이드라인이 포함된 Markdown 본문
+
+**SKILL.md 예제:**
+
+````markdown
+---
+name: github-actions-failure-debugging
+description: 실패한 GitHub Actions 워크플로우 디버깅 가이드.
+---
+
+실패한 GitHub Actions 워크플로우를 디버깅하려면:
+
+1. `list_workflow_runs`를 사용하여 최근 워크플로우 실행을 조회
+2. `summarize_job_log_failures`를 사용하여 실패한 작업의 AI 요약을 가져옴
+3. 필요한 경우 `get_job_logs`로 상세 실패 로그를 가져옴
+4. 환경에서 실패를 재현해 봄
+5. 실패한 빌드를 수정
+````
+
+작업을 수행할 때 Copilot은 프롬프트와 스킬 설명을 기반으로 스킬 사용 시점을 결정합니다. `SKILL.md` 파일은 에이전트의 컨텍스트에 주입됩니다.
+
+### MCP 서버 사용 (Claude Desktop)
+
+설정 파일을 편집합니다:
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+
+설정 예시:
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/Users/username/Desktop"
+      ]
+    }
+  }
+}
 ```
 
 ---
@@ -325,6 +400,29 @@ description: 이 스킬이 하는 일에 대한 명확한 설명.
 [실제 예제]
 ```
 
+### MCP 서버 예제 (Python)
+
+외부 데이터 소스에 연결해야 하는 스킬의 경우 MCP 서버를 만들 수 있습니다:
+
+```bash
+pip install fastmcp
+```
+
+server.py:
+```python
+from fastmcp import FastMCP
+
+mcp = FastMCP("My Server")
+
+@mcp.tool()
+def hello_world(name: str = "World") -> str:
+    """A simple tool that says hello."""
+    return f"Hello, {name}!"
+
+if __name__ == "__main__":
+    mcp.run()
+```
+
 ---
 
 ## 커뮤니티 리소스
@@ -334,6 +432,10 @@ description: 이 스킬이 하는 일에 대한 명확한 설명.
 - [Wikipedia](https://python.langchain.com/docs/integrations/tools/wikipedia/) - Wikipedia에서 요약 가져오기
 - [Python REPL](https://python.langchain.com/docs/integrations/tools/python/) - Python 코드 실행
 - [Custom Tools Guide](https://python.langchain.com/docs/how_to/custom_tools/) - `@tool` 데코레이터 사용 지침
+
+### 기사 및 연구
+- [I found 50 companies accidentally breaking HIPAA with ChatGPT](https://dev.to/dannwaneri/i-found-50-companies-accidentally-breaking-hipaa-with-chatgpt-1olc) - AI의 개인정보 위험 분석
+- [I built a Production RAG System for $5/month](https://dev.to/dannwaneri/i-built-a-production-rag-system-for-5month-most-alternatives-cost-100-200-21hj) - RAG 아키텍처 비용 최적화 가이드
 
 ---
 
@@ -355,23 +457,34 @@ Agent Skills는 AI 비서에게 특정 작업을 수행하는 방법을 가르�
 
 ### 어떤 AI 도구가 Agent Skills를 지원하나요?
 
-현재 지원되는 도구는 **Claude**(Claude.ai 및 Claude Code), **GitHub Copilot**, **VS Code** 등입니다. 표준을 채택하는 도구가 늘어남에 따라 목록이 확장되고 있습니다.
+현재 지원: **Claude** (Claude.ai 및 Claude Code), **GitHub Copilot**, **VS Code**, **Codex** (OpenAI), **Antigravity** (Google), **Gemini CLI**, **Kiro**. 더 많은 도구가 표준을 채택함에 따라 목록이 계속 늘어나고 있습니다.
 
 ### Agent Skills는 코드를 실행하나요?
 
 아니요. 스킬은 단순한 텍스트 지침이며 AI는 이를 레시피처럼 읽고 따릅니다. 실제 코드를 실행해야 하는 경우 스킬과 함께 MCP 서버 등을 사용합니다.
 
+### 첫 번째 Agent Skill은 어떻게 만드나요?
+
+1. `SKILL.md` 파일을 만들고 상단에 이름과 설명을 작성합니다
+2. 파일에 명확한 단계별 지침을 작성합니다
+3. `.github/skills/` 또는 `.claude/skills/` 폴더에 넣습니다
+4. 테스트해 보세요!
+
+전체 가이드: [커스텀 스킬 만드는 방법](https://support.claude.com/en/articles/12512198-creating-custom-skills)
+
 ---
 
 ## 기여하기
 
-이 저장소는 Agent Skills 개방형 개발 모델을 따릅니다. 더 넓은 생태계의 기여를 환영합니다. 기여할 때:
+기여를 환영합니다. 전체 가이드라인은 **[CONTRIBUTING.md](CONTRIBUTING.md)**를 참조하세요.
 
-- 스킬 템플릿 구조를 따르세요.
-- 명확하고 실행 가능한 지침을 제공하세요.
-- 적절한 경우 작동하는 예제를 포함하세요.
-- 장단점과 잠재적인 문제를 문서화하세요.
-- 최적의 성능을 위해 SKILL.md를 500줄 미만으로 유지하세요.
+빠른 요약:
+- 스킬 템플릿 구조를 따르세요
+- 명확하고 실행 가능한 지침을 제공하세요
+- 적절한 경우 작동하는 예제를 포함하세요
+- 트레이드오프와 잠재적 문제를 문서화하세요
+- 최적의 성능을 위해 SKILL.md를 500줄 이하로 유지하세요
+- 추가하기 전에 스킬이 실제로 존재하는지 확인하세요
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ They do different things and work great together:
 
 ### Which AI tools support Agent Skills?
 
-Currently supported: **Claude** (Claude.ai and Claude Code), **GitHub Copilot**, **VS Code**, and others. The list is growing as more tools adopt the standard.
+Currently supported: **Claude** (Claude.ai and Claude Code), **GitHub Copilot**, **VS Code**, **Codex** (OpenAI), **Antigravity** (Google), **Gemini CLI**, and **Kiro**. The list is growing as more tools adopt the standard.
 
 ### Do Agent Skills run code?
 
@@ -483,8 +483,9 @@ Full guide: [How to create custom skills](https://support.claude.com/en/articles
 
 ## Contributing
 
-This repository follows the Agent Skills open development model. Contributions are welcome from the broader ecosystem. When contributing:
+Contributions are welcome. See **[CONTRIBUTING.md](CONTRIBUTING.md)** for full guidelines.
 
+Quick summary:
 - Follow the skill template structure
 - Provide clear, actionable instructions
 - Include working examples where appropriate

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -124,6 +124,8 @@ Codex 支持不同范围的技能：
 | [kukapay/crypto-skills](https://github.com/kukapay/crypto-skills) | 加密货币、Web3 和区块链技能 |
 | [chadboyda/agent-gtm-skills](https://github.com/chadboyda/agent-gtm-skills) | 18 项市场推广技能：定价、外展、SEO、广告、留存和运营 |
 | [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 项产品管理技能，涵盖发现、定义、交付和优化 |
+| [sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills) | Google Workspace（Gmail、Chat、Calendar、Docs、Drive、Sheets、Slides）、AI 委托（Jules、Manus、Deep Research）和数据库技能 |
+| [RioBot-Grind/agentfund-skill](https://github.com/RioBot-Grind/agentfund-skill) | Base 链上 AI 代理的众筹 — 里程碑托管 |
 
 #### 文档处理
 
@@ -178,14 +180,6 @@ Codex 支持不同范围的技能：
 | [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace) | 评估代码实现计划 |
 | [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace) | 检测失败测试并提出修复建议 |
 
-#### 协作与项目管理
-
-| 技能 | 描述 |
-|------|------|
-| [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace) | 自动化 git 操作和仓库交互 |
-| [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace) | 评估代码实施计划 |
-| [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace) | 检测失败的测试并提出修复建议 |
-
 #### 安全和系统
 
 | 技能 | 描述 |
@@ -204,14 +198,6 @@ Codex 支持不同范围的技能：
 | [Context Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) | 上下文工程技术 |
 | [Pomodoro System Skill](https://github.com/jakedahn/pomodoro) | 系统技能模式（记忆并改进的技能） |
 | [Mind Cloning](https://github.com/yzfly/Mind-Cloning-Engineering) | 使用 LLM 技能进行思维克隆 |
-
-#### 高级与研究
-
-| 技能 | 描述 |
-|------|------|
-| [Context Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) | 上下文工程技术 |
-| [Pomodoro System Skill](https://github.com/jakedahn/pomodoro) | 系统技能模式（记忆和改进的技能） |
-| [Mind Cloning](https://github.com/yzfly/Mind-Cloning-Engineering) | 通过 LLM 技能进行思维克隆 |
 
 ---
 
@@ -259,6 +245,37 @@ cp -r skill-name ~/.claude/skills/
 
 技能会自动加载并在相关时激活。
 
+### 在 Codex 中使用技能
+
+**创建技能：**
+
+使用 Codex 内置的 `$skill-creator` 技能。描述你想让技能做什么，Codex 会自动为你创建。
+
+如果你使用 `$skill-installer create-plan` 安装了 `$create-plan`（实验性），Codex 会在写入文件之前创建计划。
+
+你也可以通过创建一个包含 `SKILL.md` 文件的文件夹来手动创建技能：
+
+````markdown
+---
+name: skill-name
+description: 帮助 Codex 选择技能的描述
+metadata:
+  short-description: 可选的面向用户的描述
+---
+
+使用此技能时 Codex 代理应遵循的技能指令。
+````
+
+**安装新技能：**
+
+使用 `$skill-installer` 技能从 GitHub 下载技能：
+
+```bash
+$skill-installer linear
+```
+
+你也可以指示安装程序从其他仓库下载技能。安装技能后，重启 Codex 以加载新技能。
+
 ### 在 VS Code 中使用技能
 
 技能存储在包含 `SKILL.md` 文件的目录中。VS Code 支持两个位置：
@@ -281,6 +298,62 @@ description: 技能的功能描述和使用时机
 # 技能指令
 
 你的详细指令、指南和示例...
+```
+
+### 在 Copilot CLI 中使用技能
+
+**将技能添加到你的仓库：**
+
+1. 创建 `.github/skills` 目录（`.claude/skills` 中的技能也受支持）
+2. 为你的技能创建子目录（例如 `.github/skills/webapp-testing`）
+3. 创建包含技能指令的 `SKILL.md` 文件
+
+**SKILL.md 结构：**
+
+- `name`（必需）：使用连字符代替空格的唯一小写标识符
+- `description`（必需）：技能的功能以及 Copilot 何时应使用它
+- `license`（可选）：适用于此技能的许可证
+- 包含指令、示例和指南的 Markdown 正文
+
+**SKILL.md 示例：**
+
+````markdown
+---
+name: github-actions-failure-debugging
+description: 调试失败的 GitHub Actions 工作流程的指南。
+---
+
+调试失败的 GitHub Actions 工作流程：
+
+1. 使用 `list_workflow_runs` 查找最近的工作流程运行
+2. 使用 `summarize_job_log_failures` 获取失败作业的 AI 摘要
+3. 如需详细失败日志，使用 `get_job_logs`
+4. 尝试在你的环境中重现故障
+5. 修复失败的构建
+````
+
+执行任务时，Copilot 根据你的提示和技能描述决定何时使用技能。`SKILL.md` 文件会注入到代理的上下文中。
+
+### 使用 MCP 服务器（Claude Desktop）
+
+编辑你的配置文件：
+- **macOS**：`~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**：`%APPDATA%\Claude\claude_desktop_config.json`
+
+配置示例：
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/Users/username/Desktop"
+      ]
+    }
+  }
+}
 ```
 
 ---
@@ -325,6 +398,31 @@ description: 清楚描述此技能的功能。
 [实际示例]
 ```
 
+### MCP 服务器示例（Python）
+
+对于需要连接外部数据源的技能，你可以创建 MCP 服务器：
+
+```bash
+pip install fastmcp
+```
+
+server.py：
+```python
+from fastmcp import FastMCP
+
+mcp = FastMCP("My Server")
+
+@mcp.tool()
+def hello_world(name: str = "World") -> str:
+    """A simple tool that says hello."""
+    return f"Hello, {name}!"
+
+if __name__ == "__main__":
+    mcp.run()
+```
+
+---
+
 ## 社区资源
 
 ### LangChain Tools
@@ -332,6 +430,10 @@ description: 清楚描述此技能的功能。
 - [Wikipedia](https://python.langchain.com/docs/integrations/tools/wikipedia/) - 从维基百科获取摘要
 - [Python REPL](https://python.langchain.com/docs/integrations/tools/python/) - 执行 Python 代码
 - [Custom Tools Guide](https://python.langchain.com/docs/how_to/custom_tools/) - 如何使用 `@tool` 装饰器
+
+### 文章与研究
+- [I found 50 companies accidentally breaking HIPAA with ChatGPT](https://dev.to/dannwaneri/i-found-50-companies-accidentally-breaking-hipaa-with-chatgpt-1olc) - AI 隐私风险分析
+- [I built a Production RAG System for $5/month](https://dev.to/dannwaneri/i-built-a-production-rag-system-for-5month-most-alternatives-cost-100-200-21hj) - RAG 架构成本优化指南
 
 ---
 
@@ -353,23 +455,34 @@ Agent Skills 是教导 AI 助理如何执行特定任务的指令文件。将它
 
 ### 哪些 AI 工具支持 Agent Skills？
 
-目前支持：**Claude**（Claude.ai 和 Claude Code）、**GitHub Copilot**、**VS Code** 等。随着更多工具采用此标准，列表正在增长。
+目前支持：**Claude**（Claude.ai 和 Claude Code）、**GitHub Copilot**、**VS Code**、**Codex**（OpenAI）、**Antigravity**（Google）、**Gemini CLI** 和 **Kiro**。随着更多工具采用该标准，列表还在不断增长。
 
 ### Agent Skills 会执行代码吗？
 
 不会。技能只是文本指令，AI 像阅读食谱一样阅读和遵循。如果需要执行实际代码，你可以搭配技能使用 MCP 服务器。
 
+### 如何创建我的第一个 Agent Skill？
+
+1. 创建一个 `SKILL.md` 文件，在顶部写上名称和描述
+2. 在文件中编写清晰的逐步指令
+3. 将其放在 `.github/skills/` 或 `.claude/skills/` 文件夹中
+4. 测试一下！
+
+完整指南：[如何创建自定义技能](https://support.claude.com/en/articles/12512198-creating-custom-skills)
+
 ---
 
 ## 贡献
 
-此仓库遵循 Agent Skills 开放开发模式。欢迎来自更广泛生态系统的贡献。贡献时请：
+欢迎贡献。完整指南请参阅 **[CONTRIBUTING.md](CONTRIBUTING.md)**。
 
+快速摘要：
 - 遵循技能模板结构
 - 提供清晰、可操作的指令
-- 在适当时包含有效示例
+- 在适当的地方包含可运行的示例
 - 记录权衡和潜在问题
-- 将 SKILL.md 保持在 500 行以下以获得最佳性能
+- 为了最佳性能，将 SKILL.md 保持在 500 行以下
+- 在添加之前验证技能确实存在
 
 ---
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -124,6 +124,8 @@ Codex 支援不同範圍的技能：
 | [kukapay/crypto-skills](https://github.com/kukapay/crypto-skills) | 加密貨幣、Web3 和區塊鏈技能 |
 | [chadboyda/agent-gtm-skills](https://github.com/chadboyda/agent-gtm-skills) | 18 項市場推廣技能：定價、外展、SEO、廣告、留存和營運 |
 | [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 項產品管理技能，涵蓋探索、定義、交付和優化 |
+| [sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills) | Google Workspace（Gmail、Chat、Calendar、Docs、Drive、Sheets、Slides）、AI 委託（Jules、Manus、Deep Research）和資料庫技能 |
+| [RioBot-Grind/agentfund-skill](https://github.com/RioBot-Grind/agentfund-skill) | Base 鏈上 AI 代理的群眾募資 — 里程碑託管 |
 
 #### 文件處理
 
@@ -178,14 +180,6 @@ Codex 支援不同範圍的技能：
 | [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace) | 評估程式碼實作計畫 |
 | [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace) | 偵測失敗測試並提出修正建議 |
 
-#### 協作與專案管理
-
-| 技能 | 描述 |
-|------|------|
-| [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace) | 自動化 git 操作和倉庫互動 |
-| [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace) | 評估程式碼實施計畫 |
-| [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace) | 檢測失敗的測試並提出修復建議 |
-
 #### 安全和系統
 
 | 技能 | 描述 |
@@ -204,14 +198,6 @@ Codex 支援不同範圍的技能：
 | [Context Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) | 上下文工程技術 |
 | [Pomodoro System Skill](https://github.com/jakedahn/pomodoro) | 系統技能模式（記憶並改進的技能） |
 | [Mind Cloning](https://github.com/yzfly/Mind-Cloning-Engineering) | 使用 LLM 技能進行思維複製 |
-
-#### 進階與研究
-
-| 技能 | 描述 |
-|------|------|
-| [Context Engineering](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering) | 上下文工程技術 |
-| [Pomodoro System Skill](https://github.com/jakedahn/pomodoro) | 系統技能模式（記憶和改進的技能） |
-| [Mind Cloning](https://github.com/yzfly/Mind-Cloning-Engineering) | 透過 LLM 技能進行思維複製 |
 
 ---
 
@@ -259,6 +245,37 @@ cp -r skill-name ~/.claude/skills/
 
 技能會自動載入並在相關時啟用。
 
+### 在 Codex 中使用技能
+
+**建立技能：**
+
+使用 Codex 內建的 `$skill-creator` 技能。描述你想讓技能做什麼，Codex 會自動為你建立。
+
+如果你使用 `$skill-installer create-plan` 安裝了 `$create-plan`（實驗性），Codex 會在寫入檔案之前建立計畫。
+
+你也可以透過建立一個包含 `SKILL.md` 檔案的資料夾來手動建立技能：
+
+````markdown
+---
+name: skill-name
+description: 幫助 Codex 選擇技能的描述
+metadata:
+  short-description: 選擇性的面向使用者描述
+---
+
+使用此技能時 Codex 代理應遵循的技能指令。
+````
+
+**安裝新技能：**
+
+使用 `$skill-installer` 技能從 GitHub 下載技能：
+
+```bash
+$skill-installer linear
+```
+
+你也可以指示安裝程式從其他儲存庫下載技能。安裝技能後，重新啟動 Codex 以載入新技能。
+
 ### 在 VS Code 中使用技能
 
 技能儲存在包含 `SKILL.md` 檔案的目錄中。VS Code 支援兩個位置：
@@ -281,6 +298,62 @@ description: 技能的功能描述和使用時機
 # 技能指令
 
 你的詳細指令、指南和範例...
+```
+
+### 在 Copilot CLI 中使用技能
+
+**將技能新增到你的儲存庫：**
+
+1. 建立 `.github/skills` 目錄（`.claude/skills` 中的技能也受支援）
+2. 為你的技能建立子目錄（例如 `.github/skills/webapp-testing`）
+3. 建立包含技能指令的 `SKILL.md` 檔案
+
+**SKILL.md 結構：**
+
+- `name`（必要）：使用連字號代替空格的唯一小寫識別碼
+- `description`（必要）：技能的功能以及 Copilot 何時應使用它
+- `license`（選擇性）：適用於此技能的授權條款
+- 包含指令、範例和指南的 Markdown 正文
+
+**SKILL.md 範例：**
+
+````markdown
+---
+name: github-actions-failure-debugging
+description: 除錯失敗的 GitHub Actions 工作流程的指南。
+---
+
+除錯失敗的 GitHub Actions 工作流程：
+
+1. 使用 `list_workflow_runs` 查詢最近的工作流程執行
+2. 使用 `summarize_job_log_failures` 取得失敗工作的 AI 摘要
+3. 如需詳細失敗日誌，使用 `get_job_logs`
+4. 嘗試在你的環境中重現故障
+5. 修復失敗的建置
+````
+
+執行任務時，Copilot 根據你的提示和技能描述決定何時使用技能。`SKILL.md` 檔案會注入到代理的上下文中。
+
+### 使用 MCP 伺服器（Claude Desktop）
+
+編輯你的設定檔：
+- **macOS**：`~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**：`%APPDATA%\Claude\claude_desktop_config.json`
+
+設定範例：
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/Users/username/Desktop"
+      ]
+    }
+  }
+}
 ```
 
 ---
@@ -325,6 +398,31 @@ description: 清楚描述此技能的功能。
 [實際範例]
 ```
 
+### MCP 伺服器範例（Python）
+
+對於需要連接外部資料來源的技能，你可以建立 MCP 伺服器：
+
+```bash
+pip install fastmcp
+```
+
+server.py：
+```python
+from fastmcp import FastMCP
+
+mcp = FastMCP("My Server")
+
+@mcp.tool()
+def hello_world(name: str = "World") -> str:
+    """A simple tool that says hello."""
+    return f"Hello, {name}!"
+
+if __name__ == "__main__":
+    mcp.run()
+```
+
+---
+
 ## 社群資源
 
 ### LangChain Tools
@@ -332,6 +430,10 @@ description: 清楚描述此技能的功能。
 - [Wikipedia](https://python.langchain.com/docs/integrations/tools/wikipedia/) - 從維基百科取得摘要
 - [Python REPL](https://python.langchain.com/docs/integrations/tools/python/) - 執行 Python 程式碼
 - [Custom Tools Guide](https://python.langchain.com/docs/how_to/custom_tools/) - 如何使用 `@tool` 裝飾器
+
+### 文章與研究
+- [I found 50 companies accidentally breaking HIPAA with ChatGPT](https://dev.to/dannwaneri/i-found-50-companies-accidentally-breaking-hipaa-with-chatgpt-1olc) - AI 隱私風險分析
+- [I built a Production RAG System for $5/month](https://dev.to/dannwaneri/i-built-a-production-rag-system-for-5month-most-alternatives-cost-100-200-21hj) - RAG 架構成本最佳化指南
 
 ---
 
@@ -353,23 +455,34 @@ Agent Skills 是教導 AI 助理如何執行特定任務的指令檔案。將它
 
 ### 哪些 AI 工具支援 Agent Skills？
 
-目前支援：**Claude**（Claude.ai 和 Claude Code）、**GitHub Copilot**、**VS Code** 等。隨著更多工具採用此標準，列表正在增長。
+目前支援：**Claude**（Claude.ai 和 Claude Code）、**GitHub Copilot**、**VS Code**、**Codex**（OpenAI）、**Antigravity**（Google）、**Gemini CLI** 和 **Kiro**。隨著更多工具採用該標準，列表還在不斷增長。
 
 ### Agent Skills 會執行程式碼嗎？
 
 不會。技能只是文字指令，AI 像閱讀食譜一樣閱讀和遵循。如果需要執行實際程式碼，你可以搭配技能使用 MCP 伺服器。
 
+### 如何建立我的第一個 Agent Skill？
+
+1. 建立一個 `SKILL.md` 檔案，在頂部寫上名稱和描述
+2. 在檔案中編寫清晰的逐步指令
+3. 將其放在 `.github/skills/` 或 `.claude/skills/` 資料夾中
+4. 測試一下！
+
+完整指南：[如何建立自訂技能](https://support.claude.com/en/articles/12512198-creating-custom-skills)
+
 ---
 
 ## 貢獻
 
-此倉庫遵循 Agent Skills 開放開發模式。歡迎來自更廣泛生態系統的貢獻。貢獻時請：
+歡迎貢獻。完整指南請參閱 **[CONTRIBUTING.md](CONTRIBUTING.md)**。
 
+快速摘要：
 - 遵循技能範本結構
 - 提供清晰、可操作的指令
-- 在適當時包含有效範例
+- 在適當的地方包含可運行的範例
 - 記錄權衡和潛在問題
-- 將 SKILL.md 保持在 500 行以下以獲得最佳效能
+- 為了最佳效能，將 SKILL.md 保持在 500 行以下
+- 在新增之前驗證技能確實存在
 
 ---
 


### PR DESCRIPTION
## Summary

- **Sync 6 missing sections** to all 5 translated READMEs (es, ja, ko, zh-CN, zh-TW):
  - Using Skills in Codex
  - Using Skills in Copilot CLI
  - Using MCP Servers (Claude Desktop)
  - MCP Server Example (Python)
  - Articles & Research
  - "How do I create my first Agent Skill?" FAQ
- **Update FAQ** "Which AI tools support Agent Skills?" to list all 7 supported platforms (Claude, Copilot, VS Code, Codex, Antigravity, Gemini CLI, Kiro) across all 6 files
- **Add missing Skill Collections entries** (sanjay3290/ai-skills, agentfund-skill) to translated READMEs
- **Fix duplicate sections** in translations (Collaboration & Advanced sections appeared twice)
- **Create `CONTRIBUTING.md`** with entry format, quality checklist, translation guidelines, and PR guidance
- **Update Contributing section** in all 6 READMEs to reference CONTRIBUTING.md

## Test plan

- [ ] Verify all 6 READMEs render correctly on GitHub
- [ ] Grep for "Gemini CLI", "Codex", "Copilot CLI", "fastmcp", "CONTRIBUTING" in all files
- [ ] Confirm no conflict markers (`<<<<<<<`) in any file
- [ ] Verify no duplicate section headers in translated READMEs
- [ ] Spot-check zh-CN and zh-TW for proper Simplified/Traditional Chinese

🤖 Generated with [Claude Code](https://claude.com/claude-code)