### PR TITLE
Add Flutter skills repo to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Community-maintained skills and collections (verify before use):
 | [Tool Advisor](https://github.com/dragon1086/claude-skills) | Analyzes prompts and recommends optimal tools, skills, agents, and orchestration patterns |
 | [Vibe Testing](https://github.com/knot0-com/vibe-testing) | Pressure-test spec documents with LLM reasoning before writing code |
 | [Mantra](https://mantra.gonewx.com) | AI coding session management - save, restore, and time-travel through Claude Code, Cursor, and Windsurf sessions |
-| [Wreos/mobile-app-developer (Flutter skills)](https://github.com/Wreos/mobile-app-developer/tree/main/platforms/Flutter/skills) | Community Flutter skills for implementation, testing, API integration, debugging, and release workflows |
+| [Dart/Flutter](https://github.com/Wreos/mobile-app-developer/tree/main/platforms/Flutter/skills) | Community Flutter skills for implementation, testing, API integration, debugging, and release workflows |
 
 #### Data & Analysis
 


### PR DESCRIPTION
## Summary

Adds Flutter skills to the **Community Skill Collections** section of README.md.

## What's included

- UI implementation with Flutter widgets
- Testing (unit, widget, integration)
- REST API & backend integration
- Debugging and performance profiling
- App release and deployment workflows

## Link

https://github.com/Wreos/mobile-app-developer/tree/main/platforms/Flutter/skills

## Checklist

- [x] Entry follows the table format defined in CONTRIBUTING.md
- [x] Link points directly to the skills directory