### PR TITLE
Add deapi-ai/claude-code-skills to Integration & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Community-maintained skills and collections (verify before use):
 | [AgentStore](https://github.com/techgangboss/agentstore) | Open-source plugin marketplace with gasless USDC payments, CLI install, and 3-field publishing API |
 | [Transloadit Skills](https://github.com/transloadit/skills) | Media processing: video encoding, image manipulation, OCR, and 86+ Robots |
 | [commune](https://github.com/shanjairaj7/commune-skill) | Agent-native email inbox — permanent @commune.ai address with full send/receive, semantic search, triage, and webhooks |
+| [deapi-ai/claude-code-skills](https://github.com/deapi-ai/claude-code-skills) | AI media generation via natural language — image creation (Flux), TTS, transcription, video generation, OCR, upscaling & background removal via deAPI.ai |
 
 #### Collaboration & Project Management
 


### PR DESCRIPTION
Hi! 👋

Adding [deapi-ai/claude-code-skills](https://github.com/deapi-ai/claude-code-skills) to the Integration & Automation section.

**What it does:** AI media generation via natural language — image creation (Flux), text-to-speech, audio/video transcription, OCR, video generation, upscaling, and background removal. All through a single `SKILL.md` install.

**Compatible with:** Claude Code, Cursor, Windsurf, Continue.dev, and other AGENTS.md-compatible tools.

**Easy to try:** Powered by [deAPI.ai](https://deapi.ai/) — $5 free credit on signup, no credit card required, no subscription.

MIT licensed. Thanks for maintaining this list! 🙏