### PR TITLE
Add Taskade MCP to Integration & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Community-maintained skills and collections (verify before use):
 | [AgentStore](https://github.com/techgangboss/agentstore) | Open-source plugin marketplace with gasless USDC payments, CLI install, and 3-field publishing API |
 | [Transloadit Skills](https://github.com/transloadit/skills) | Media processing: video encoding, image manipulation, OCR, and 86+ Robots |
 | [commune](https://github.com/shanjairaj7/commune-skill) | Agent-native email inbox — permanent @commune.ai address with full send/receive, semantic search, triage, and webhooks |
+| [Taskade MCP](https://github.com/taskade/mcp) | AI-native workspace MCP server with 50+ tools for project management, task automation, knowledge bases, and multi-agent workflows |
 
 #### Collaboration & Project Management
 


### PR DESCRIPTION
## Summary

Adds [Taskade MCP](https://github.com/taskade/mcp) to the **Integration & Automation** section under Community Skills.

Taskade MCP is an MCP server providing 50+ tools for AI agents to manage projects, automate tasks, access knowledge bases, and orchestrate multi-agent workflows. It enables AI coding agents to interact with the Taskade workspace programmatically.

- **MCP Server:** https://github.com/taskade/mcp
- **Website:** https://taskade.com

The entry follows the existing table format used in the section.