### PR TITLE
Add rule-porter — AI IDE rule format converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Community-maintained skills and collections (verify before use):
 | [Stream Coding](https://github.com/frmoretto/stream-coding) | Stream Coding methodology |
 | [SwiftUI Skills](https://github.com/ameyalambat128/swiftui-skills) | Apple-authored SwiftUI and platform guidance extracted from Xcode |
 | [Tool Advisor](https://github.com/dragon1086/claude-skills) | Analyzes prompts and recommends optimal tools, skills, agents, and orchestration patterns |
+| [rule-porter](https://github.com/nedcodes-ok/rule-porter) | Convert AI IDE rules between Cursor (.mdc), CLAUDE.md, AGENTS.md, Copilot, and Windsurf. Bidirectional, zero dependencies |
 | [Vibe Testing](https://github.com/knot0-com/vibe-testing) | Pressure-test spec documents with LLM reasoning before writing code |
 | [Mantra](https://mantra.gonewx.com) | AI coding session management - save, restore, and time-travel through Claude Code, Cursor, and Windsurf sessions |
 


### PR DESCRIPTION
Adds [rule-porter](https://github.com/nedcodes-ok/rule-porter) to the Development & Code Tools section.

rule-porter converts AI IDE rule files between Cursor (.mdc), CLAUDE.md, AGENTS.md, GitHub Copilot, and Windsurf formats. Bidirectional conversion, zero dependencies, runs via npx.

npm: https://www.npmjs.com/package/rule-porter