### PR TITLE
Add noizai/skills to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Community-maintained skills and collections (verify before use):
 | [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 product management skills covering discovery, definition, delivery, and optimization |
 | [sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills) | Google Workspace (Gmail, Chat, Calendar, Docs, Drive, Sheets, Slides), AI delegation (Jules, Manus, Deep Research), and database skills |
 | [RioBot-Grind/agentfund-skill](https://github.com/RioBot-Grind/agentfund-skill) | Crowdfunding for AI agents on Base chain - milestone escrow |
+| [noizai/skills](https://github.com/noizai/skills) | Voice-first skills: TTS with SRT dubbing and companion voice presets |
 
 #### Document Processing
 


### PR DESCRIPTION
Add NoizAI's public skill collection repository to the Skill Collections table.

Highlights:
- includes `tts` for Kokoro/Noiz TTS with SRT/timeline-aligned dubbing workflows
- includes `characteristic-voice` for companion-like speech presets and filler/emotion tuning

Repo: https://github.com/noizai/skills

Made with [Cursor](https://cursor.com)