### PR TITLE
Add meyhem-search to Integration & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,8 @@ Community-maintained skills and collections (verify before use):
 | [Transloadit Skills](https://github.com/transloadit/skills) | Media processing: video encoding, image manipulation, OCR, and 86+ Robots |
 | [commune](https://github.com/shanjairaj7/commune-skill) | Agent-native email inbox — permanent @commune.ai address with full send/receive, semantic search, triage, and webhooks |
 
+| [meyhem-search](https://github.com/c5huracan/meyhem) | Agent-native web search with feedback-driven ranking via REST API and MCP server |
+
 #### Collaboration & Project Management
 
 | Skill | Description |


### PR DESCRIPTION
Adding [meyhem-search](https://github.com/c5huracan/meyhem) to Integration & Automation.

Agent-native web search with feedback-driven ranking. Free, no API key. REST API + MCP server.

- [x] Public and accessible
- [x] Correct section (Integration & Automation)
- [x] One-line neutral description
- [x] Table row format
- [x] Verified working
- [x] No duplicates