### PR TITLE
Add dna-claude-analysis to Data & Analysis section

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Community-maintained skills and collections (verify before use):
 |-------|-------------|
 | [CSV Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) | Analyze CSV files and generate insights with visualizations |
 | [Kaggle Skill](https://github.com/shepsci/kaggle-skill) | Complete Kaggle integration — account setup, competition reports, dataset/model downloads, notebook execution, submissions, and badge collection |
+| [DNA Claude Analysis](https://github.com/shmlkv/dna-claude-analysis) | Personal genome analysis toolkit with Python scripts analyzing raw DNA data across 17 categories and generating terminal-style HTML visualization |
 
 #### Integration & Automation
 


### PR DESCRIPTION
## Description

Adds [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) to the **Data & Analysis** section.

**dna-claude-analysis** is a personal genome analysis toolkit with Python scripts that analyze raw DNA data across 17 categories (health risks, ancestry, nutrition, sports, pharmacogenomics, longevity, and more) and generate a terminal-style single-page HTML visualization.

## Checklist

- [x] Skill/project exists and is publicly accessible
- [x] Entry follows the existing table format
- [x] Description is concise and accurate
- [x] Placed in the appropriate section (Data & Analysis)