### PR TITLE
Add Linked API skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,8 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [Linked-API/linkedin-skills](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin) - General-purpose LinkedIn automation through Linked API: profiles, search, messaging, connections, posts, reactions, comments, and workflows
+- [Linked-API/linkedin-growth](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin-growth) - LinkedIn growth pipeline for lead import, ICP qualification, scheduled invites, acceptance tracking, and stale pending cleanup
 </details>
 
 <details>


### PR DESCRIPTION
Adds both Linked API agent skills to the Community Skills > Productivity and Collaboration section.

- `linkedin`: general-purpose LinkedIn automation through Linked API.
- `linkedin-growth`: managed LinkedIn lead import, ICP qualification, scheduling, and cleanup workflows.

This updates the original `vprudnikoff` PR branch on top of the current `main` branch and replaces the stale LinkedIn-only README entry with the current two-skill submission.

Checks:
- README-only change.
