### PR TITLE
Add survivorforge/cursor-rules to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Community-maintained skills and collections (verify before use):
 | [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 product management skills covering discovery, definition, delivery, and optimization |
 | [sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills) | Google Workspace (Gmail, Chat, Calendar, Docs, Drive, Sheets, Slides), AI delegation (Jules, Manus, Deep Research), and database skills |
 | [RioBot-Grind/agentfund-skill](https://github.com/RioBot-Grind/agentfund-skill) | Crowdfunding for AI agents on Base chain - milestone escrow |
+| [survivorforge/cursor-rules](https://github.com/survivorforge/cursor-rules) | 35+ .cursorrules files for 16 frameworks (React, Next.js, Python, Go, Rust, TypeScript, Vue, Angular, and more) |
 
 #### Document Processing
 


### PR DESCRIPTION
## Summary

- Adds [survivorforge/cursor-rules](https://github.com/survivorforge/cursor-rules) to the **Skill Collections** section
- 35+ `.cursorrules` files covering 16 frameworks (React, Next.js, Python, Go, Rust, TypeScript, Vue, Angular, and more)
- Entry added at the end of the Skill Collections table per CONTRIBUTING.md guidelines

## Checklist

- [x] Repository is public and accessible
- [x] Entry placed in correct section (Skill Collections)
- [x] Description is one line, neutral, and factual
- [x] Uses table row format
- [x] No duplicate entries
- [x] English-only change (translations can be synced by maintainers)