### PR TITLE
Add playwright skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Community-maintained skills and collections (verify before use):
 | [AgentStore](https://github.com/techgangboss/agentstore) | Open-source plugin marketplace with gasless USDC payments, CLI install, and 3-field publishing API |
 | [Transloadit Skills](https://github.com/transloadit/skills) | Media processing: video encoding, image manipulation, OCR, and 86+ Robots |
 | [commune](https://github.com/shanjairaj7/commune-skill) | Agent-native email inbox — permanent @commune.ai address with full send/receive, semantic search, triage, and webhooks |
-
+| [playwright-skill](https://github.com/testdino-hq/playwright-skill) | 70+ structured Playwright testing skill for AI agents covering end-to-end tests, page object models, CI/CD setup, Cypress or Selenium migration, and CLI automation |
 
 
 #### Collaboration & Project Management


### PR DESCRIPTION
Adds [testdino-hq/playwright-skill](https://github.com/testdino-hq/playwright-skill) to the Development & Code Tools section.

70+ structured Playwright testing skill for AI agents — covers end-to-end tests, page object models, CI/CD setup, Cypress/Selenium migration, and CLI automation.