### PR TITLE
Add Production Grade — 14-agent orchestrator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Community-maintained skills and collections (verify before use):
 | [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 product management skills covering discovery, definition, delivery, and optimization |
 | [sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills) | Google Workspace (Gmail, Chat, Calendar, Docs, Drive, Sheets, Slides), AI delegation (Jules, Manus, Deep Research), and database skills |
 | [RioBot-Grind/agentfund-skill](https://github.com/RioBot-Grind/agentfund-skill) | Crowdfunding for AI agents on Base chain - milestone escrow |
+| [production-grade](https://github.com/nagisanzenin/claude-code-production-grade-plugin) | 14-agent autonomous pipeline from idea to production-ready SaaS. Two-wave parallel execution, Polymath co-pilot, brownfield-safe. |
 
 #### Document Processing
 


### PR DESCRIPTION
## Summary

- Adds [production-grade](https://github.com/nagisanzenin/claude-code-production-grade-plugin) to the **Skill Collections** table under Community Skills.
- 14-agent autonomous pipeline that takes a project from idea to production-ready SaaS with two-wave parallel execution, a Polymath co-pilot, and brownfield-safe design.

## Details

The entry follows the existing table format (`| Repository | Description |`) and is appended to the end of the Skill Collections section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)