### PR TITLE
Add MachFive Cold Email skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Community-maintained skills and collections (verify before use):
 | [AgentStore](https://github.com/techgangboss/agentstore) | Open-source plugin marketplace with gasless USDC payments, CLI install, and 3-field publishing API |
 | [Transloadit Skills](https://github.com/transloadit/skills) | Media processing: video encoding, image manipulation, OCR, and 86+ Robots |
 | [commune](https://github.com/shanjairaj7/commune-skill) | Agent-native email inbox — permanent @commune.ai address with full send/receive, semantic search, triage, and webhooks |
+| [MachFive Cold Email](https://github.com/Bluecraft-AI/machfive-skills) | Generate hyper-personalized cold email sequences via the MachFive API. Supports single lead and batch processing with async polling. |
 
 #### Collaboration & Project Management
 


### PR DESCRIPTION
- Repo: https://github.com/Bluecraft-AI/machfive-skills
- Compatible with: Claude Code, Codex CLI, Gemini CLI
- License: MIT
- Requires: MACHFIVE_API_KEY