### PR TITLE
Add EmblemAI crypto wallet skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Community-maintained skills and collections (verify before use):
 | [gotalab/skillport](https://github.com/gotalab/skillport) | Skills distribution via CLI or MCP |
 | [mhattingpete/claude-skills-marketplace](https://github.com/mhattingpete/claude-skills-marketplace) | Git, code review, and testing skills |
 | [kukapay/crypto-skills](https://github.com/kukapay/crypto-skills) |  cryptocurrency, web3 and blockchain skills. |
+| [EmblemCompany/Agent-skills](https://github.com/EmblemCompany/Agent-skills/tree/main/skills/emblem-ai-agent-wallet) | Crypto wallet management across 7 blockchains (Solana, Ethereum, Base, BSC, Polygon, Hedera, Bitcoin) via EmblemAI. Swaps, transfers, portfolio analysis. |
 | [chadboyda/agent-gtm-skills](https://github.com/chadboyda/agent-gtm-skills) | 18 go-to-market skills: pricing, outbound, SEO, ads, retention, and ops |
 | [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 product management skills covering discovery, definition, delivery, and optimization |
 | [sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills) | Google Workspace (Gmail, Chat, Calendar, Docs, Drive, Sheets, Slides), AI delegation (Jules, Manus, Deep Research), and database skills |


### PR DESCRIPTION
Add EmblemAI crypto wallet skill to the Skill Collections table.

- Multi-chain wallet management (7 blockchains)
- npm: [@emblemvault/agentwallet](https://www.npmjs.com/package/@emblemvault/agentwallet)
- Listed on: skills.sh, SkillsMP, ClawHub
- License: MIT