### PR TITLE
Add Frostbyte MCP to Integration & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Community-maintained skills and collections (verify before use):
 | [AgentStore](https://github.com/techgangboss/agentstore) | Open-source plugin marketplace with gasless USDC payments, CLI install, and 3-field publishing API |
 | [Transloadit Skills](https://github.com/transloadit/skills) | Media processing: video encoding, image manipulation, OCR, and 86+ Robots |
 | [commune](https://github.com/shanjairaj7/commune-skill) | Agent-native email inbox — permanent @commune.ai address with full send/receive, semantic search, triage, and webhooks |
+| [Frostbyte MCP](https://github.com/Robocular/frostbyte-mcp) | MCP server providing 40+ developer API tools — crypto wallets, domain registration, screenshots, scraping, DNS, and geolocation |
 
 #### Collaboration & Project Management
 


### PR DESCRIPTION
Adds [Frostbyte MCP](https://github.com/Robocular/frostbyte-mcp) to the **Integration & Automation** section.

**What it is:** An MCP server that provides 40+ developer API tools — crypto wallet management, domain registration, website screenshots, web scraping, DNS lookups, and geolocation.

**Checklist:**
- [x] Repository is public and accessible (no 404)
- [x] Entry placed in correct section (Integration & Automation)
- [x] Description is one line, neutral, and factual
- [x] Entry uses table row format
- [x] Tool works (published Docker image + npm package)
- [x] No duplicate entries