### PR TITLE
chore: update Agent Governance Toolkit URLs to microsoft/ org

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -189,7 +189,7 @@ Habilidades y colecciones mantenidas por la comunidad (verificar antes de usar):
 | [Threat Hunting](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) | Caza de amenazas usando reglas de detección Sigma |
 | [Vincent Wallet](https://github.com/HeyVincent-ai/agent-skills/tree/main/wallet) | Wallet EVM seguro para agentes — transferencias, intercambios y transacciones |
 | [Vincent Polymarket](https://github.com/HeyVincent-ai/agent-skills/tree/main/polymarket) | Trading en mercados de predicción Polymarket para agentes |
-| [Agent OS Governance](https://github.com/imran-siddique/agent-os) | Gobernanza a nivel de kernel para agentes de IA — aplicación determinista de políticas, verificación de cumplimiento, registro de auditoría |
+| [Agent OS Governance](https://github.com/microsoft/agent-governance-toolkit) | Gobernanza a nivel de kernel para agentes de IA — aplicación determinista de políticas, verificación de cumplimiento, registro de auditoría |
 
 #### Avanzado e Investigación
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -189,7 +189,7 @@ Codexは異なるスコープのスキルをサポートしています：
 | [Threat Hunting](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) | Sigma検出ルールを使用した脅威ハンティング |
 | [Vincent Wallet](https://github.com/HeyVincent-ai/agent-skills/tree/main/wallet) | エージェント用セキュアEVMウォレット — 送金、スワップ、トランザクション |
 | [Vincent Polymarket](https://github.com/HeyVincent-ai/agent-skills/tree/main/polymarket) | エージェント用Polymarket予測市場取引 |
-| [Agent OS Governance](https://github.com/imran-siddique/agent-os) | AIエージェントのカーネルレベルガバナンス — 決定的ポリシー実行、コンプライアンスチェック、監査ログ |
+| [Agent OS Governance](https://github.com/microsoft/agent-governance-toolkit) | AIエージェントのカーネルレベルガバナンス — 決定的ポリシー実行、コンプライアンスチェック、監査ログ |
 
 #### 上級・研究
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -189,7 +189,7 @@ Codex는 다양한 범위의 스킬을 지원합니다:
 | [Threat Hunting](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) | Sigma 탐지 규칙을 사용한 위협 사냥 |
 | [Vincent Wallet](https://github.com/HeyVincent-ai/agent-skills/tree/main/wallet) | 에이전트용 보안 EVM 지갑 — 전송, 스왑, 트랜잭션 |
 | [Vincent Polymarket](https://github.com/HeyVincent-ai/agent-skills/tree/main/polymarket) | 에이전트용 Polymarket 예측 시장 거래 |
-| [Agent OS Governance](https://github.com/imran-siddique/agent-os) | AI 에이전트 커널 수준 거버넌스 — 결정적 정책 실행, 규정 준수 검사, 감사 로깅 |
+| [Agent OS Governance](https://github.com/microsoft/agent-governance-toolkit) | AI 에이전트 커널 수준 거버넌스 — 결정적 정책 실행, 규정 준수 검사, 감사 로깅 |
 
 #### 고급 및 연구
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Community-maintained skills and collections (verify before use):
 | [Threat Hunting](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) | Hunt for threats using Sigma detection rules |
 | [Vincent Wallet](https://github.com/HeyVincent-ai/agent-skills/tree/main/wallet) | Secure EVM wallet for agent transfers, swaps, and transactions |
 | [Vincent Polymarket](https://github.com/HeyVincent-ai/agent-skills/tree/main/polymarket) | Polymarket prediction market trading for agents |
-| [Agent OS Governance](https://github.com/imran-siddique/agent-os) | Kernel-level governance for AI agents — deterministic policy enforcement, compliance checking, audit logging |
+| [Agent OS Governance](https://github.com/microsoft/agent-governance-toolkit) | Kernel-level governance for AI agents — deterministic policy enforcement, compliance checking, audit logging |
 
 #### Advanced & Research
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -189,7 +189,7 @@ Codex 支持不同范围的技能：
 | [Threat Hunting](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) | 使用 Sigma 检测规则进行威胁狩猎 |
 | [Vincent Wallet](https://github.com/HeyVincent-ai/agent-skills/tree/main/wallet) | 代理用安全 EVM 钱包，支持转账、交换和交易 |
 | [Vincent Polymarket](https://github.com/HeyVincent-ai/agent-skills/tree/main/polymarket) | 代理用 Polymarket 预测市场交易 |
-| [Agent OS Governance](https://github.com/imran-siddique/agent-os) | AI 代理的内核级治理 — 确定性策略执行、合规检查、审计日志 |
+| [Agent OS Governance](https://github.com/microsoft/agent-governance-toolkit) | AI 代理的内核级治理 — 确定性策略执行、合规检查、审计日志 |
 
 #### 高级与研究
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -189,7 +189,7 @@ Codex 支援不同範圍的技能：
 | [Threat Hunting](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) | 使用 Sigma 偵測規則進行威脅狩獵 |
 | [Vincent Wallet](https://github.com/HeyVincent-ai/agent-skills/tree/main/wallet) | 代理用安全 EVM 錢包，支援轉帳、交換和交易 |
 | [Vincent Polymarket](https://github.com/HeyVincent-ai/agent-skills/tree/main/polymarket) | 代理用 Polymarket 預測市場交易 |
-| [Agent OS Governance](https://github.com/imran-siddique/agent-os) | AI 代理的核心層治理 — 確定性政策執行、合規檢查、稽核紀錄 |
+| [Agent OS Governance](https://github.com/microsoft/agent-governance-toolkit) | AI 代理的核心層治理 — 確定性政策執行、合規檢查、稽核紀錄 |
 
 #### 進階與研究
 


### PR DESCRIPTION
The Agent Governance Toolkit has moved to [microsoft/agent-governance-toolkit](https://github.com/microsoft/agent-governance-toolkit). This PR updates URLs to the new location.