### PR TITLE
Add swift-ios-skills to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Community-maintained skills and collections (verify before use):
 | [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 product management skills covering discovery, definition, delivery, and optimization |
 | [sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills) | Google Workspace (Gmail, Chat, Calendar, Docs, Drive, Sheets, Slides), AI delegation (Jules, Manus, Deep Research), and database skills |
 | [RioBot-Grind/agentfund-skill](https://github.com/RioBot-Grind/agentfund-skill) | Crowdfunding for AI agents on Base chain - milestone escrow |
+| [dpearson2699/swift-ios-skills](https://github.com/dpearson2699/swift-ios-skills) | 23 iOS 26+ and Swift 6.2 skills covering SwiftUI, SwiftData, StoreKit, concurrency, networking, and more |
 
 #### Document Processing
 


### PR DESCRIPTION
Adds [dpearson2699/swift-ios-skills](https://github.com/dpearson2699/swift-ios-skills) to the **Skill Collections** section.

23 iOS 26+ and Swift 6.2 agent skills covering SwiftUI, SwiftData, StoreKit, concurrency, networking, and more. Compatible with Claude Code, Codex, Cursor, Copilot, and other agents following the Agent Skills standard.

## Checklist

- [x] Repository is public and accessible
- [x] Entry placed in the correct section (Skill Collections)
- [x] Description is one line, neutral, and factual
- [x] Entry uses table row format
- [x] Skill works as described
- [x] No duplicate entries