### PR TITLE
Add NoizAI/skills to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Community-maintained skills and collections (verify before use):
 | [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 product management skills covering discovery, definition, delivery, and optimization |
 | [sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills) | Google Workspace (Gmail, Chat, Calendar, Docs, Drive, Sheets, Slides), AI delegation (Jules, Manus, Deep Research), and database skills |
 | [RioBot-Grind/agentfund-skill](https://github.com/RioBot-Grind/agentfund-skill) | Crowdfunding for AI agents on Base chain - milestone escrow |
+| [NoizAI/skills](https://github.com/NoizAI/skills) | Human-like TTS workflow skills with local/cloud options and app delivery |
 
 #### Document Processing
 


### PR DESCRIPTION
## Summary
- add one table row for `NoizAI/skills` in **Skill Collections**
- keep wording neutral and one-line, matching CONTRIBUTING requirements

## Why
- addresses the repository submission request for NoizAI/skills listing

Closes #84

Made with [Cursor](https://cursor.com)