### PR TITLE
Add skill: readtheskill/readtheskill

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Community-maintained skills and collections (verify before use):
 | [gotalab/skillport](https://github.com/gotalab/skillport) | Skills distribution via CLI or MCP |
 | [mhattingpete/claude-skills-marketplace](https://github.com/mhattingpete/claude-skills-marketplace) | Git, code review, and testing skills |
 | [kukapay/crypto-skills](https://github.com/kukapay/crypto-skills) |  cryptocurrency, web3 and blockchain skills. |
+| [readtheskill/readtheskill](https://github.com/readtheskill/readtheskill) | AI agent skill propagation experiment on Solana with live tracking |
 | [chadboyda/agent-gtm-skills](https://github.com/chadboyda/agent-gtm-skills) | 18 go-to-market skills: pricing, outbound, SEO, ads, retention, and ops |
 | [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 product management skills covering discovery, definition, delivery, and optimization |
 | [sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills) | Google Workspace (Gmail, Chat, Calendar, Docs, Drive, Sheets, Slides), AI delegation (Jules, Manus, Deep Research), and database skills |


### PR DESCRIPTION
Adds [readtheskill](https://github.com/readtheskill/readtheskill) to the Community Skills collection.

Open-source AI agent skill propagation experiment on Solana with live discovery tracking at [readtheskill.com](https://readtheskill.com). Published on skills.sh and ClawHub.