### PR TITLE
Add community-demand-prospecting-skill to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Community-maintained skills and collections (verify before use):
 | [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 product management skills covering discovery, definition, delivery, and optimization |
 | [sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills) | Google Workspace (Gmail, Chat, Calendar, Docs, Drive, Sheets, Slides), AI delegation (Jules, Manus, Deep Research), and database skills |
 | [RioBot-Grind/agentfund-skill](https://github.com/RioBot-Grind/agentfund-skill) | Crowdfunding for AI agents on Base chain - milestone escrow |
+| [cuongducle/community-demand-prospecting-skill](https://github.com/cuongducle/community-demand-prospecting-skill) | Repo audit, market research, positioning, and community outreach planning |
 
 #### Document Processing
 


### PR DESCRIPTION
## Summary
- add `cuongducle/community-demand-prospecting-skill` to the Skill Collections table
- use a neutral one-line description matching the repository guidelines

## Why
This repository packages a reusable SKILL.md-based workflow for repo audit, market research, positioning, and community outreach planning.