### PR TITLE
Add ClawdVault to Integration & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Community-maintained skills and collections (verify before use):
 | [Spotify Skill](https://github.com/fabioc-aloha/spotify-skill) | Spotify API integration |
 | [AgentStore](https://github.com/techgangboss/agentstore) | Open-source plugin marketplace with gasless USDC payments, CLI install, and 3-field publishing API |
 | [Transloadit Skills](https://github.com/transloadit/skills) | Media processing: video encoding, image manipulation, OCR, and 86+ Robots |
+| [ClawdVault](https://github.com/inavhq/clawdvault-skill) | Free ERC-20 token launches on Base via API or social post — Clanker/Uniswap V4 deploy, creator earns 80% LP fees |
 | [commune](https://github.com/shanjairaj7/commune-skill) | Agent-native email inbox — permanent @commune.ai address with full send/receive, semantic search, triage, and webhooks |
 
 #### Collaboration & Project Management


### PR DESCRIPTION
Adds [ClawdVault](https://github.com/inavhq/clawdvault-skill) to the Integration & Automation section.

**What it does:** Free ERC-20 token launches on Base for AI agents. Deploys via Clanker (Uniswap V4), creator earns 80% of LP trading fees in WETH. No API key or registration needed.

**Checklist:**
- [x] Skill exists and is publicly accessible
- [x] SKILL.md with YAML frontmatter
- [x] One table row, neutral description
- [x] Correct section (Integration & Automation)
- [x] No duplicates in existing list