### PR TITLE
Add steel-browser to Integration & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Community-maintained skills and collections (verify before use):
 | [AgentStore](https://github.com/techgangboss/agentstore) | Open-source plugin marketplace with gasless USDC payments, CLI install, and 3-field publishing API |
 | [Transloadit Skills](https://github.com/transloadit/skills) | Media processing: video encoding, image manipulation, OCR, and 86+ Robots |
 | [commune](https://github.com/shanjairaj7/commune-skill) | Agent-native email inbox — permanent @commune.ai address with full send/receive, semantic search, triage, and webhooks |
+| [steel-browser](https://github.com/steel-dev/cli/tree/main/skills/steel-browser) | Session-backed browser automation skill for web navigation, extraction, screenshots, and PDFs |
 
 #### Collaboration & Project Management
 


### PR DESCRIPTION
`steel-browser` is a skill for running session-backed browser workflows through Steel cloud browsers and CLI tooling.

It fits `Integration & Automation` because the skill handles website navigation, extraction, screenshots, PDFs, and multi-step flows that need a persistent browser session.

Links:
- Skill: https://github.com/steel-dev/cli/tree/main/skills/steel-browser
- Repo: https://github.com/steel-dev/cli
- Docs: https://docs.steel.dev/llms-full.txt
- Blog: https://steel.dev/blog/introducing-steel-cli-v0-2-0-browser-automation-built-for-agents

Example use case: browser automation + skill orchestration for dynamic sites and artifact capture.