### PR TITLE
Add TestDino Playwright skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Community-maintained skills and collections (verify before use):
 | [Stream Coding](https://github.com/frmoretto/stream-coding) | Stream Coding methodology |
 | [SwiftUI Skills](https://github.com/ameyalambat128/swiftui-skills) | Apple-authored SwiftUI and platform guidance extracted from Xcode |
 | [Tool Advisor](https://github.com/dragon1086/claude-skills) | Analyzes prompts and recommends optimal tools, skills, agents, and orchestration patterns |
+| [TestDino Playwright Skill](https://github.com/testdino-hq/playwright-skill) | Structured Playwright testing skill for AI agents covering end-to-end tests, page object models, CI/CD setup, Cypress or Selenium migration, and CLI automation |
 | [Vibe Testing](https://github.com/knot0-com/vibe-testing) | Pressure-test spec documents with LLM reasoning before writing code |
 | [Mantra](https://mantra.gonewx.com) | AI coding session management - save, restore, and time-travel through Claude Code, Cursor, and Windsurf sessions |
 


### PR DESCRIPTION
## Summary
Adds `playwright-skill` .

## Details
- 70+ structured Playwright testing skill for AI agents
- Covers end-to-end tests, page object models, CI/CD setup, Cypress or Selenium migration, and CLI automation

## Notes
Kept the format consistent with the existing list style.