### PR TITLE
Add ProxyClaw — Residential proxy skill for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Community-maintained skills and collections (verify before use):
 | [AgentStore](https://github.com/techgangboss/agentstore) | Open-source plugin marketplace with gasless USDC payments, CLI install, and 3-field publishing API |
 | [Transloadit Skills](https://github.com/transloadit/skills) | Media processing: video encoding, image manipulation, OCR, and 86+ Robots |
 | [commune](https://github.com/shanjairaj7/commune-skill) | Agent-native email inbox — permanent @commune.ai address with full send/receive, semantic search, triage, and webhooks |
+| [ProxyClaw](https://github.com/Iploop/proxyclaw) | Residential proxy SDK for AI agents — 2M+ IPs, 195+ countries, anti-bot bypass, geo-targeting. `pip install iploop-sdk` or `clawhub install proxyclaw` |
 
 #### Collaboration & Project Management
 


### PR DESCRIPTION
## ProxyClaw by IPLoop

Adding [ProxyClaw](https://github.com/Iploop/proxyclaw) to the Integration & Automation section.

**What it does:** Gives AI agents access to 2M+ residential proxy IPs across 195+ countries. Anti-bot bypass, geo-targeting, IP rotation, sticky sessions.

**Install:** `clawhub install proxyclaw` or `pip install iploop-sdk`

**Why it belongs here:** It's a published skill on ClawHub with SKILL.md, fetch.sh, and setup.sh. Enables any AI agent to scrape the web through residential IPs with a single command.

**Checklist:**
- [x] Public and accessible repository
- [x] Placed in correct section (Integration & Automation)
- [x] Short, neutral description
- [x] Published on ClawHub, PyPI, and npm