### PR TITLE
Add web-architect: 4-agent design-to-code pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ Community-maintained skills and collections (verify before use):
 | [Stream Coding](https://github.com/frmoretto/stream-coding) | Stream Coding methodology |
 | [SwiftUI Skills](https://github.com/ameyalambat128/swiftui-skills) | Apple-authored SwiftUI and platform guidance extracted from Xcode |
 | [Tool Advisor](https://github.com/dragon1086/claude-skills) | Analyzes prompts and recommends optimal tools, skills, agents, and orchestration patterns |
+| [Web Architect](https://github.com/choppawave-beep/web-architect) | 4-agent orchestrator for design-to-code pipelines — Constrained Generation, 8 project profiles, 5-dimension quality scoring |
 | [Vibe Testing](https://github.com/knot0-com/vibe-testing) | Pressure-test spec documents with LLM reasoning before writing code |
-| [web-architect](https://github.com/choppawave-beep/web-architect) | 4-agent orchestrator for full design-to-code pipelines with Constrained Generation, 8 project profiles, 5-dimension quality scoring |
 | [Mantra](https://mantra.gonewx.com) | AI coding session management - save, restore, and time-travel through Claude Code, Cursor, and Windsurf sessions |
 
 #### Data & Analysis


### PR DESCRIPTION
## New Skill: web-architect

Adds [web-architect](https://github.com/choppawave-beep/web-architect) to the **Development & Code Tools** section.

- **Repository**: [choppawave-beep/web-architect](https://github.com/choppawave-beep/web-architect)
- **Description**: 4-agent orchestrator for full design-to-code pipelines with Constrained Generation, 8 project profiles, 5-dimension quality scoring
- **Install**: `npx skills add choppawave-beep/web-architect`

### What it does

web-architect orchestrates 4 specialized agents (Designer, Architect, Builder, QA) to handle end-to-end web design and development workflows. It features Constrained Generation for deterministic output quality, 8 pre-configured project profiles, and a 5-dimension scoring system for automated quality assessment.

### Checklist

- [x] Skill repository exists and is public
- [x] Entry follows existing table format
- [x] Placed in appropriate category (Development & Code Tools)
- [x] Description is concise and informative