### PR TITLE
Add ai-native-cli skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Community-maintained skills and collections (verify before use):
 | [Tool Advisor](https://github.com/dragon1086/claude-skills) | Analyzes prompts and recommends optimal tools, skills, agents, and orchestration patterns |
 | [Vibe Testing](https://github.com/knot0-com/vibe-testing) | Pressure-test spec documents with LLM reasoning before writing code |
 | [Mantra](https://mantra.gonewx.com) | AI coding session management - save, restore, and time-travel through Claude Code, Cursor, and Windsurf sessions |
+| [ai-native-cli](https://github.com/ChaosRealmsAI/agent-cli-spec) | CLI design spec — 98 rules for building agent-safe CLI tools |
 
 #### Data & Analysis
 


### PR DESCRIPTION
## Summary
- Add **ai-native-cli** to the Development & Code Tools section
- ai-native-cli is a CLI design spec with 98 rules for building agent-safe CLI tools
- Repository: https://github.com/ChaosRealmsAI/agent-cli-spec

## Test plan
- [x] Entry follows existing table format (`| [Name](url) | Description |`)
- [x] Placed in the correct category (Development & Code Tools)
- [x] Link is valid and points to a public repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)