### PR TITLE
Add affiliate-skills — 45 AI agent skills for affiliate marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Community-maintained skills and collections (verify before use):
 | [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 product management skills covering discovery, definition, delivery, and optimization |
 | [sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills) | Google Workspace (Gmail, Chat, Calendar, Docs, Drive, Sheets, Slides), AI delegation (Jules, Manus, Deep Research), and database skills |
 | [RioBot-Grind/agentfund-skill](https://github.com/RioBot-Grind/agentfund-skill) | Crowdfunding for AI agents on Base chain - milestone escrow |
+| [Affitor/affiliate-skills](https://github.com/Affitor/affiliate-skills) | 45 open-source skills for affiliate marketing. Full 8-stage flywheel with skill chaining. Follows agentskills.io standard. `npx skills add Affitor/affiliate-skills` |
 
 #### Document Processing
 


### PR DESCRIPTION
## Add affiliate-skills

**Repository:** https://github.com/Affitor/affiliate-skills
**License:** MIT
**Skills:** 45
**Standard:** [agentskills.io](https://agentskills.io)

### What it is

45 open-source AI agent skills for affiliate marketing. Full funnel: research, content, SEO, landing pages, distribution, analytics, automation. Works with Claude Code, ChatGPT, Gemini, Cursor, Windsurf.

### Compatibility

Claude Code, ChatGPT, Gemini CLI, Cursor, Windsurf, OpenClaw, any AI agent.

### Install

```bash
npx skills add Affitor/affiliate-skills
```

### Why include it

- Largest open-source affiliate marketing skill collection (45 skills)
- Follows agentskills.io standard
- Full funnel coverage (8 stages with closed-loop flywheel)
- Works across all major AI coding agents
- Active development, MIT licensed