### PR TITLE
Add codex-stitch-local

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Community-maintained skills and collections (verify before use):
 | [SwiftUI Skills](https://github.com/ameyalambat128/swiftui-skills) | Apple-authored SwiftUI and platform guidance extracted from Xcode |
 | [Tool Advisor](https://github.com/dragon1086/claude-skills) | Analyzes prompts and recommends optimal tools, skills, agents, and orchestration patterns |
 | [Vibe Testing](https://github.com/knot0-com/vibe-testing) | Pressure-test spec documents with LLM reasoning before writing code |
+| [codex-stitch-local](https://github.com/yshishenya/codex-stitch-local) | Stitch UI generation with local HTML and screenshots |
 | [Mantra](https://mantra.gonewx.com) | AI coding session management - save, restore, and time-travel through Claude Code, Cursor, and Windsurf sessions |
 
 #### Data & Analysis


### PR DESCRIPTION
## Summary
- add `codex-stitch-local` to Development & Code Tools
- include a concise description focused on Stitch UI generation and local artifacts

## Why
`codex-stitch-local` packages Google Stitch into a portable skill bundle for Codex, Claude Code, and OpenClaw, with local HTML and screenshot outputs.
