### PR TITLE
Add StitchFlow to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Community-maintained skills and collections (verify before use):
 | [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 product management skills covering discovery, definition, delivery, and optimization |
 | [sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills) | Google Workspace (Gmail, Chat, Calendar, Docs, Drive, Sheets, Slides), AI delegation (Jules, Manus, Deep Research), and database skills |
 | [RioBot-Grind/agentfund-skill](https://github.com/RioBot-Grind/agentfund-skill) | Crowdfunding for AI agents on Base chain - milestone escrow |
+| [yshishenya/stitchflow](https://github.com/yshishenya/stitchflow) | Cross-agent UI design skill collection for turning briefs and mockups into screens, variants, HTML, and screenshots |
 
 #### Document Processing
 


### PR DESCRIPTION
## Summary
- add StitchFlow to the Skill Collections table

## Why
StitchFlow is a public cross-agent skill collection for turning briefs and mockups into screens, design variants, Tailwind-ready HTML, and screenshots across Codex, Claude Code, OpenClaw, GitHub Copilot, and Gemini CLI.