### PR TITLE
Add datadog-observability to Integration & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Community-maintained skills and collections (verify before use):
 | [AgentStore](https://github.com/techgangboss/agentstore) | Open-source plugin marketplace with gasless USDC payments, CLI install, and 3-field publishing API |
 | [Transloadit Skills](https://github.com/transloadit/skills) | Media processing: video encoding, image manipulation, OCR, and 86+ Robots |
 | [commune](https://github.com/shanjairaj7/commune-skill) | Agent-native email inbox — permanent @commune.ai address with full send/receive, semantic search, triage, and webhooks |
+| [datadog-observability](https://github.com/Ivlad003/plugins) | Query and analyze Datadog logs, metrics, monitors, and traces directly from Claude Code via REST API |
 
 #### Collaboration & Project Management
 


### PR DESCRIPTION
## Summary
- Adds [datadog-observability](https://github.com/Ivlad003/plugins) plugin to the **Integration & Automation** section
- Query and analyze Datadog logs, metrics, monitors, and traces directly from Claude Code via REST API

## Details
- 5 slash commands: `/dd-logs`, `/dd-query`, `/dd-alerts`, `/dd-status`, `/dd-investigate`
- Auto-activated `datadog-ops` skill with 12 API operations
- `datadog-investigator` agent for incident root cause analysis
- Uses curl directly — no MCP server or extra dependencies
- MIT licensed, public repo, tested and working

Closes #120