### PR TITLE
Add bitcoin-mcp to Integration & Automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Community-maintained skills and collections (verify before use):
 | [AgentStore](https://github.com/techgangboss/agentstore) | Open-source plugin marketplace with gasless USDC payments, CLI install, and 3-field publishing API |
 | [Transloadit Skills](https://github.com/transloadit/skills) | Media processing: video encoding, image manipulation, OCR, and 86+ Robots |
 | [commune](https://github.com/shanjairaj7/commune-skill) | Agent-native email inbox — permanent @commune.ai address with full send/receive, semantic search, triage, and webhooks |
+| [bitcoin-mcp](https://github.com/Bortlesboat/bitcoin-mcp) | Bitcoin MCP server with 49 tools — fee intelligence, mempool analysis, block/transaction inspection, mining stats, price and supply data |
 
 #### Collaboration & Project Management
 


### PR DESCRIPTION
## Summary

- Adds [bitcoin-mcp](https://github.com/Bortlesboat/bitcoin-mcp) to the Integration & Automation section
- Bitcoin MCP server with 49 tools for AI agents: fee intelligence, mempool analysis, block/transaction inspection, mining stats, price and supply data
- Listed on the [Anthropic MCP Registry](https://github.com/modelcontextprotocol/servers), MIT licensed, available on PyPI (`bitcoin-mcp`)

## Checklist

- [x] Repository is public and accessible
- [x] Entry placed in correct section (Integration & Automation)
- [x] Description is one line, neutral, and factual
- [x] Uses table row format
- [x] Tool works and is actively maintained
- [x] No duplicate entries