### PR TITLE
Add Skillfold to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Community-maintained skills and collections (verify before use):
 | [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 product management skills covering discovery, definition, delivery, and optimization |
 | [sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills) | Google Workspace (Gmail, Chat, Calendar, Docs, Drive, Sheets, Slides), AI delegation (Jules, Manus, Deep Research), and database skills |
 | [RioBot-Grind/agentfund-skill](https://github.com/RioBot-Grind/agentfund-skill) | Crowdfunding for AI agents on Base chain - milestone escrow |
+| [byronxlg/skillfold](https://github.com/byronxlg/skillfold) | YAML compiler for multi-agent pipelines - compiles one config into skills for 11 platforms (Claude Code, Cursor, Copilot, Gemini, and more) with 11 reusable library skills |
 
 #### Document Processing
 


### PR DESCRIPTION
**[engineer]**

Adds [Skillfold](https://github.com/byronxlg/skillfold) to the Skill Collections section.

Skillfold is a YAML-based configuration language and compiler for multi-agent AI pipelines. It compiles a single config file into agent skills for 11 platforms (Claude Code, Cursor, Copilot, Gemini, Codex, Windsurf, Goose, Roo Code, Kiro, Junie, and Agent Teams) and ships with 11 reusable library skills. MIT licensed.

## Checklist

- [x] Repository is public and accessible
- [x] Entry placed in correct section (Skill Collections)
- [x] Description is one line, neutral, and factual
- [x] Entry uses table row format
- [x] Verified the tool works
- [x] No duplicate entries