### PR TITLE
Add hand-drawn-diagrams: Excalidraw diagram skill with animation and hosted edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Community-maintained skills and collections (verify before use):
 |-------|-------------|
 | [aws-skills](https://github.com/zxkane/aws-skills) | AWS development with CDK best practices |
 | [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) | D3 charts and interactive data visualizations |
+| [hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams) | Generate hand-drawn Excalidraw diagrams from a prompt — animated SVG, hosted edit link, and PNG export. Works with Claude Code, Codex, and any agent supporting standard skill paths |
 | [Playwright Automation](https://github.com/lackeyjb/playwright-skill) | Browser automation for testing web apps |
 | [Specrate](https://github.com/rickygao/specrate) | Manage specs and changes in a structured workflow |
 | [iOS Simulator](https://github.com/conorluddy/ios-simulator-skill) | Interact with iOS Simulator for testing |


### PR DESCRIPTION
## Add hand-drawn-diagrams

**Repo:** https://github.com/muthuishere/hand-drawn-diagrams  
**Author:** Muthukumaran Navaneethakrishnan ([@muthuishere](https://github.com/muthuishere))

### What it does

An agent skill that generates hand-drawn Excalidraw diagrams from a natural language prompt. It picks the right diagram type (architecture, UX flows, teaching diagrams, funnels, wireframes…), lays out the elements, and delivers:

- A hosted edit link — opens in Excalidraw editor in the browser, no app install needed
- An animated SVG that draws itself stroke by stroke
- PNG export on request

Works with Claude Code, Codex, and any agent supporting standard skill paths.

### Why it fits here

Added to **Development & Code Tools** alongside D3.js Visualization — useful for architects, developers, and designers who want diagrams without starting from a blank canvas.