### PR TITLE
Add naming to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Community-maintained skills and collections (verify before use):
 | [Tool Advisor](https://github.com/dragon1086/claude-skills) | Analyzes prompts and recommends optimal tools, skills, agents, and orchestration patterns |
 | [Vibe Testing](https://github.com/knot0-com/vibe-testing) | Pressure-test spec documents with LLM reasoning before writing code |
 | [Mantra](https://mantra.gonewx.com) | AI coding session management - save, restore, and time-travel through Claude Code, Cursor, and Windsurf sessions |
+| [naming](https://github.com/glacierphonk/naming) | Metaphor-driven naming for products, SaaS, brands, and open source projects |
 
 #### Data & Analysis
 


### PR DESCRIPTION
Adds the naming skill to the Development & Code Tools section.

A Claude Code skill for naming products, SaaS, brands, bots, and open source projects using a structured metaphor-driven process. MIT licensed.

https://github.com/glacierphonk/naming