### PR TITLE
Add claude-dev-skill to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Community-maintained skills and collections (verify before use):
 | [Tool Advisor](https://github.com/dragon1086/claude-skills) | Analyzes prompts and recommends optimal tools, skills, agents, and orchestration patterns |
 | [Vibe Testing](https://github.com/knot0-com/vibe-testing) | Pressure-test spec documents with LLM reasoning before writing code |
 | [Mantra](https://mantra.gonewx.com) | AI coding session management - save, restore, and time-travel through Claude Code, Cursor, and Windsurf sessions |
+| [claude-dev-skill](https://github.com/hnaymyh123-henry/claude-dev-skill) | Turns Claude into a Tech Lead orchestrating parallel Worker Agents through a full dev workflow: PRD alignment, architecture, coding, QA, and PR review |
 
 #### Data & Analysis
 


### PR DESCRIPTION
## Description

Adding `claude-dev-skill` to the **Development & Code Tools** section.

## Skill Details

- **Name:** claude-dev-skill
- **Repository:** https://github.com/hnaymyh123-henry/claude-dev-skill
- **Description:** Turns Claude into a Tech Lead orchestrating parallel Worker Agents through a full dev workflow: PRD alignment, architecture, coding, QA, and PR review.

## Why it fits

This skill implements a multi-agent software development workflow using Claude Code's subagent capabilities. It covers the full dev lifecycle (PRD → architecture → parallel coding → QA → PR review) and is designed specifically for Claude Code's skill system with a proper `SKILL.md`.

## Checklist

- [x] Link is accessible and public
- [x] Description is concise and factual (no promotional language)
- [x] Correct section (Development & Code Tools)
- [x] No duplicates
- [x] One skill added per PR