### PR TITLE
Add browser-act/skills to Skill Collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Community-maintained skills and collections (verify before use):
 | [product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 product management skills covering discovery, definition, delivery, and optimization |
 | [sanjay3290/ai-skills](https://github.com/sanjay3290/ai-skills) | Google Workspace (Gmail, Chat, Calendar, Docs, Drive, Sheets, Slides), AI delegation (Jules, Manus, Deep Research), and database skills |
 | [RioBot-Grind/agentfund-skill](https://github.com/RioBot-Grind/agentfund-skill) | Crowdfunding for AI agents on Base chain - milestone escrow |
+| [browser-act/skills](https://github.com/browser-act/skills) | 22 browser automation skills for structured data extraction from Amazon, YouTube, Google Maps, Reddit, WeChat, and Zhihu |
 
 #### Document Processing
 


### PR DESCRIPTION
Adds BrowserAct skills collection to the Skill Collections section.

BrowserAct provides 22 browser automation skills for structured data extraction from major platforms including Amazon, YouTube, Google Maps, Google News, Reddit, WeChat, and Zhihu. Each skill follows the Agent Skills specification with SKILL.md frontmatter and Python helper scripts.

- Repository is public and accessible
- Entry placed in Skill Collections section
- Description is one line, neutral, and factual
- Uses table row format
