### PR TITLE
Add claude-code skills to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Community-maintained skills and collections (verify before use):
 | [Tool Advisor](https://github.com/dragon1086/claude-skills) | Analyzes prompts and recommends optimal tools, skills, agents, and orchestration patterns |
 | [Vibe Testing](https://github.com/knot0-com/vibe-testing) | Pressure-test spec documents with LLM reasoning before writing code |
 | [Mantra](https://mantra.gonewx.com) | AI coding session management - save, restore, and time-travel through Claude Code, Cursor, and Windsurf sessions |
+| [claude-code-philosophy](https://github.com/dadwadw233/claude-code-philosophy) | Skill for reviewing and structuring agent products around harnesses, memory, permissions, recovery, and UX |
+| [claude-code-harness](https://github.com/dadwadw233/claude-code-harness) | Harness blueprint skill for request assembly, control loops, memory boundaries, permissions, and recovery |
 
 #### Data & Analysis
 


### PR DESCRIPTION
Adds two public, installable skill repositories to the Development & Code Tools section:

- `claude-code-philosophy` — skill for reviewing and structuring agent products around harnesses, memory, permissions, recovery, and UX
- `claude-code-harness` — harness blueprint skill for request assembly, control loops, memory boundaries, permissions, and recovery

Both repositories are public and currently include README, install instructions, licenses, and plugin/skill manifests for Codex and Claude Code.