### PR TITLE
Add IWE

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Community-maintained skills and collections (verify before use):
 | [Tool Advisor](https://github.com/dragon1086/claude-skills) | Analyzes prompts and recommends optimal tools, skills, agents, and orchestration patterns |
 | [Vibe Testing](https://github.com/knot0-com/vibe-testing) | Pressure-test spec documents with LLM reasoning before writing code |
 | [Mantra](https://mantra.gonewx.com) | AI coding session management - save, restore, and time-travel through Claude Code, Cursor, and Windsurf sessions |
+| [IWE](https://github.com/iwe-org/iwe) | CLI-based knowledge graph access for AI agents — structured persistent memory via plain markdown files |
 
 #### Data & Analysis
 


### PR DESCRIPTION
IWE is a markdown-based knowledge management tool that gives AI agents structured access to a knowledge graph via CLI. Agents use `iwe find` and `iwe retrieve --depth N` to query and traverse documents — deterministic retrieval without vector databases.

862+ GitHub stars, built in Rust.

GitHub: https://github.com/iwe-org/iwe