### PR TITLE
Add fastCRW web scraping skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Community-maintained skills and collections (verify before use):
 | [AgentStore](https://github.com/techgangboss/agentstore) | Open-source plugin marketplace with gasless USDC payments, CLI install, and 3-field publishing API |
 | [Transloadit Skills](https://github.com/transloadit/skills) | Media processing: video encoding, image manipulation, OCR, and 86+ Robots |
 | [commune](https://github.com/shanjairaj7/commune-skill) | Agent-native email inbox — permanent @commune.ai address with full send/receive, semantic search, triage, and webhooks |
+| [fastCRW](https://github.com/us/crw) | Scrape, crawl, map, and search the web — single Rust binary, 6MB RAM, Firecrawl-compatible API, MCP server with crw_scrape/crw_crawl/crw_map tools (`npx crw-mcp@latest init`) |
 
 #### Collaboration & Project Management
 


### PR DESCRIPTION
Add [fastCRW](https://github.com/us/crw) to the Integration & Automation section.

- **SKILL.md**: https://fastcrw.com/api/skills
- **Install**: `npx crw-mcp@latest init`
- Single Rust binary, 6MB RAM, Firecrawl-compatible API
- MCP server with crw_scrape, crw_crawl, crw_map tools