### PR TITLE
Add Global Chat agent discovery skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [pumanitro/global-chat](https://github.com/pumanitro/global-chat/tree/master/skills/agent-discovery) - Discover AI agents and MCP servers across 6+ registries
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Add [Global Chat](https://global-chat.io) to the **Community Skills > Development and Testing** section.

Global Chat is a cross-protocol AI agent discovery platform. The [agent-discovery skill](https://github.com/pumanitro/global-chat/tree/master/skills/agent-discovery) teaches AI agents how to search and discover MCP servers and AI agents across 6+ registries (18K+ servers indexed), supporting MCP, A2A, agents.txt, and other protocols.

### Skill details

- **Repo**: [pumanitro/global-chat](https://github.com/pumanitro/global-chat)
- **SKILL.md**: [skills/agent-discovery/SKILL.md](https://github.com/pumanitro/global-chat/blob/master/skills/agent-discovery/SKILL.md)
- **What it does**: Enables AI agents to discover other agents and MCP servers via API or the `@global-chat/mcp-server` npm package
- **Protocols**: MCP, A2A, agents.txt, ACDP
- **License**: MIT

### Changes

- Added one line to `README.md` under Community Skills > Development and Testing