### PR TITLE
Add Finance and Trading category with TBD

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ That's it. No installation. No configuration. No coding required.
   - [Vector Databases](#vector-databases)
   - [Marketing](#marketing)
   - [Productivity and Collaboration](#productivity-and-collaboration)
+  - [Finance and Trading](#finance-and-trading)
   - [Development and Testing](#development-and-testing)
   - [Context Engineering](#context-engineering)
 - [Skill Quality Standards](#skill-quality-standards)
@@ -539,6 +540,12 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+</details>
+
+<details>
+<summary><strong>Finance and Trading</strong></summary>
+
+- [ego-protocol/tbd-vote-cli](https://github.com/ego-protocol/tbd-vote-cli) - Trade on TBD, a Solana-based prediction market for human opinions, via the `@tbd-vote/cli` package; defers to an [AGENTS.md](https://www.tbd.vote/agents/AGENTS.md) spec for autonomous-loop instructions and HTTP fallback
 </details>
 
 <details>


### PR DESCRIPTION
Adds a new **Finance and Trading** category to Community Skills with one initial entry: TBD. Also adds the category to the Table of Contents.

[TBD](https://www.tbd.vote) is a Solana-based prediction market for human opinions — wagering on what people think and believe rather than purely objective event outcomes. The [`@tbd-vote/cli`](https://www.npmjs.com/package/@tbd-vote/cli) npm package and [SKILL.md](https://github.com/ego-protocol/tbd-vote-cli/blob/main/SKILL.md) let agents authenticate, browse opinion campaigns, and place bets via JSON-friendly commands. The skill defers to a long-form [AGENTS.md spec](https://www.tbd.vote/agents/AGENTS.md) for autonomous-loop patterns and HTTP fallback.

I added a new "Finance and Trading" category since none of the existing community categories (Vector Databases, Marketing, Productivity and Collaboration, Development and Testing, Context Engineering) is a clean fit. Happy to merge this entry into Productivity and Collaboration instead if you'd prefer not to add a new category.

- Repo: https://github.com/ego-protocol/tbd-vote-cli
- Website: https://www.tbd.vote
- AGENTS.md: https://www.tbd.vote/agents/AGENTS.md
- npm: https://www.npmjs.com/package/@tbd-vote/cli