### PR TITLE
Add Renol1/skill-creator-pro to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [Renol1/skill-creator-pro](https://github.com/Renol1/skill-creator-pro) - Production-grade skill creator with 21 patterns, self-learning training loop, and cross-platform support
 </details>
 
 <details>


### PR DESCRIPTION
## Summary
- Adds [Renol1/skill-creator-pro](https://github.com/Renol1/skill-creator-pro) to the **Development and Testing** section under Community Skills
- Production-grade skill creator with 21 patterns, self-learning training loop, and cross-platform support. Tested with 7 skills. v10.0.0.

## Test plan
- [x] Entry follows existing format (link + short description)
- [x] Placed in appropriate category (Development and Testing)
- [x] No duplicate entries