### PR TITLE
feat: add tldr skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - Document processing: convert, OCR, and redact PII
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
+- [shihyuho/tldr](https://github.com/shihyuho/skills/tree/main/skills/tldr) - Produce a TL;DR digest of files, PRs, diffs, or URLs
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
 </details>
 


### PR DESCRIPTION
A 4-sentence minimalist skill that produces TL;DR digests of any target (files, directories, PRs, diffs, URLs) in roughly 2 minutes, and suggests follow-up tldr targets when something stands out. Works with any agent that supports skills.