### PR TITLE
docs: add prooftrail context engineering entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
+- [xiaojiou176-open/prooftrail-mcp](https://github.com/xiaojiou176-open/prooftrail/tree/main/skills/prooftrail-mcp) - Governed browser-evidence MCP skill for retained proof, recovery-first review, and honest local stdio install workflows
 </details>
 
 ---


### PR DESCRIPTION
## Summary
- add `prooftrail-mcp` under the Context Engineering section
- point directly to the public skill packet in `xiaojiou176-open/prooftrail`
- describe the packet as a governed browser-evidence and recovery-first workflow, not a hosted runtime or generic marketplace listing

## Why this fits
- the indexed asset is a real `SKILL.md` packet at `skills/prooftrail-mcp/`
- it teaches context capture through retained browser evidence, proof-first review, and recovery-aware local MCP install workflows
- it is relevant to context engineering because it helps an agent move from messy browser state into inspectable evidence and a smaller next-step surface

## Boundaries
- this entry does not claim a hosted endpoint
- this entry does not claim Official MCP Registry or Smithery publication
- this entry points to the packet folder, not just the repo root
