### PR TITLE
Add SkillCompass — skill quality evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [Evol-ai/SkillCompass](https://github.com/Evol-ai/SkillCompass) - Local-first skill quality evaluator scoring 6 dimensions with fix suggestions and version tracking
 </details>
 
 <details>


### PR DESCRIPTION
Adds [SkillCompass](https://github.com/Evol-ai/SkillCompass) to the **Development and Testing** community skills section.

**What it does:** Local-first skill quality evaluator that scores six dimensions (Structure, Trigger, Security, Functional, Comparative, Uniqueness), identifies the weakest link, and guides targeted fixes with version tracking. Compatible with Claude Code, OpenClaw, and 45+ agents.

- 84+ GitHub stars
- Listed on [skills.sh](https://skills.sh/Evol-ai/SkillCompass) and [SkillsMP](https://skillsmp.com)
- Install: `npx skills add Evol-ai/SkillCompass`