### PR TITLE
feat: add AuraKit to Development and Testing — full-lifecycle Claude Code skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [smorky850612/AuraKit](https://github.com/smorky850612/Aurakit) - Full dev lifecycle skill for Claude Code: 46 modes (BUILD/FIX/DEPLOY/REVIEW/TDD/QA/DEBUG), 23 sub-agents, 6-layer OWASP+ security, ~55% token savings via Tiered Model routing
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adds **AuraKit** to the Community Skills → Development and Testing section.

### Skill Details

- **Repository**: https://github.com/smorky850612/Aurakit
- **Author**: smorky850612
- **Install**: `npx @smorky85/aurakit`
- **SKILL.md**: Included in the repository

### What it does

AuraKit is a full-lifecycle Claude Code skill framework covering the entire development workflow in a single `/aura` command:

- **46 modes**: BUILD / FIX / CLEAN / DEPLOY / REVIEW / TDD / QA / DEBUG / PAYMENT / PM / PLAN / DESIGN + more
- **23 sub-agents**: Scout, Builder, Reviewer, SecurityAgent, TestRunner (role-isolated, parallel execution)
- **6-layer OWASP+ security**: bash-guard, secret scanning, parameterized query enforcement, worktree isolation
- **Tiered Model routing**: Haiku for scan/test tasks, Sonnet for implementation → ~55% token savings
- **Instinct learning engine**: cross-session pattern accumulation — improves with use
- **8-language interface**: auto-detects Korean/English/Japanese/Chinese/French/German/Spanish/Italian

### Quality checklist

- [x] Has a valid `SKILL.md` at the repo root
- [x] Compatible with Claude Code (primary target)
- [x] Repository is public and actively maintained
- [x] Description is clear and actionable
- [x] No duplicate in current index