### PR TITLE
Add OpenAccountants to Productivity and Collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 <details>
 <summary><strong>Productivity and Collaboration</strong></summary>
 
+- [openaccountants/openaccountants](https://github.com/openaccountants/openaccountants) - 371 tax classification skills across 134 countries (VAT/GST, income tax, social contributions)
 - [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - Document processing: convert, OCR, and redact PII
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence


### PR DESCRIPTION
## Summary

- Adds [OpenAccountants](https://github.com/openaccountants/openaccountants) to the **Productivity and Collaboration** community skills section
- 371 tax classification skills across 134 countries (VAT/GST, income tax, social contributions)
- Open-source, MIT-compatible content for agent skill workflows

Made with [Cursor](https://cursor.com)