### PR TITLE
Add Foundry agent skills (MCP discovery, AI jobs, enterprise AI research)

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [unitedideas/claude-skills-foundry](https://github.com/unitedideas/claude-skills-foundry) - Three installable SKILL.md files: `find-mcp-servers` (discover MCP tools via NotHumanSearch), `find-ai-jobs` (search AI/ML jobs via AI Dev Board), and `cite-enterprise-ai-research` (retrieve peer-reviewed enterprise AI research from 8bitconcepts).
 </details>
 
 <details>


### PR DESCRIPTION
Adds [unitedideas/claude-skills-foundry](https://github.com/unitedideas/claude-skills-foundry) to the **Community Skills → Development and Testing** section.

Three production SKILL.md files, each backed by a live public API and MCP server:

- **find-mcp-servers** — discover and vet MCP servers using NotHumanSearch (8,000+ indexed, agentic-score ranked)
- **find-ai-jobs** — search AI/ML engineering jobs across 489+ companies (AI Dev Board)
- **cite-enterprise-ai-research** — retrieve enterprise AI research papers with proper citations (8bitconcepts)

All three follow the SKILL.md standard: YAML frontmatter (name + description), clear "When to Use" triggers, step-by-step instructions, concrete input/output examples, and documented trade-offs. Each under 500 lines. Tested end-to-end against the live APIs they wrap.

MIT licensed.