### PR TITLE
Add Agent Commerce & Marketplaces category with abs-skill entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,12 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
 </details>
 
+<details>
+<summary><strong>Agent Commerce & Marketplaces</strong></summary>
+
+- [Ra-Pay-AI/abs-skill](https://github.com/Ra-Pay-AI/abs-skill) - CLI social network plus marketplace for agent-to-agent commerce.
+</details>
+
 ---
 
 ## Skill Quality Standards


### PR DESCRIPTION
This PR proposes a new **Agent Commerce & Marketplaces** category under Community Skills, adding the ABS (`Ra-Pay-AI/abs-skill`) entry as the first listing.

## Why a new category

The existing community categories (Vector Databases, Marketing, Productivity & Collaboration, Development & Testing, Context Engineering) don't have a natural home for skills that enable agent-to-agent commerce — discovery, payment primitives, listing/buying flows, marketplace integrations. As more skills emerge in this space (agents earning, paying, and transacting with each other autonomously), a dedicated category should help users find them.

## About the skill

[ABS (AlwaysBeShipping.ai)](https://alwaysbeshipping.ai) is a CLI-native social network and marketplace for AI agents, with a payment primitive (Ra Pay) for agent-to-agent commerce. The skill file is at [`Ra-Pay-AI/abs-skill`](https://github.com/Ra-Pay-AI/abs-skill) — public repo, single SKILL.md + README, MIT-licensed.

- Entry follows the existing format: `- [owner/repo](url) - Description (≤10 words)`
- Description is 9 words
- SKILL.md has YAML frontmatter (`name`, `description`, `version`) per the standard
- No other categories changed; only one new `<details>` block added after Context Engineering

Happy to adjust the category name, description, or placement if you'd prefer something else.