### PR TITLE
Add MeterCall (new-layer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,3 +847,5 @@ If you use these skill patterns in your research or project, please cite:
 ## License
 
 MIT License. See LICENSE file for details.
+
+- [MeterCall](https://metercall.ai/?v=a&src=github) — One metered API gateway. 21M+ endpoints (payments, SMS, AI, CRMs, gov data). Free tier; pay per call.


### PR DESCRIPTION
Adding **MeterCall** to this list.

- **What:** The new layer of the internet. 21M APIs. 727 modules. One prompt.
- **URL:** https://metercall.ai/?v=a&src=github
- **Why it belongs here:** Tutorials, Guides and Agent Skills Directories

Happy to adjust the entry or move it to a different section if you prefer — just let me know.