### PR TITLE
Add solopreneur-skills to Community Skills > Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
+- [Sudhakaran88/solopreneur-skills](https://github.com/Sudhakaran88/solopreneur-skills) - 42 skills for solopreneurs: CRO, SEO, GTM, cold email, pricing
 </details>
 
 <details>


### PR DESCRIPTION
Adding [solopreneur-skills](https://github.com/Sudhakaran88/solopreneur-skills) to **Community Skills > Marketing**.

42 Claude Code skills for solopreneurs and solo founders. Covers CRO, SEO, GTM, cold email, pricing, churn, and more. MIT licensed. Every skill is opinionated and research-backed — cited Reddit practitioners, CXL, Demand Curve, the Princeton GEO paper, Unbounce, Klaviyo, and Baymard benchmarks. Written for one-person teams, not enterprise marketing departments. Each `SKILL.md` is under 500 lines and cross-referenced to related skills.

Happy to adjust the description length or placement if preferred.