### PR TITLE
feat(context-engineering): add fockus/skill-memory-bank

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
+- [fockus/skill-memory-bank](https://github.com/fockus/skill-memory-bank) - Cross-agent long-term project memory via `.memory-bank/` for Claude Code, Cursor, Windsurf, Cline, Kilo, OpenCode, Pi Code, Codex — bundles TDD / SOLID / Clean Architecture / FSD rules and 18 dev-toolkit commands
 </details>
 
 ---


### PR DESCRIPTION
## Summary

Adds `fockus/skill-memory-bank` to the **Context Engineering** section — cross-agent long-term project memory via `.memory-bank/` that the agent reads at session start and updates as work progresses.

## Why it fits Context Engineering

Project memory IS context engineering — the skill directly addresses the amnesia problem across sessions. It lives alongside similar entries already listed in this section:
- `muratcankoylan/memory-systems` — short-term / graph-based memory architectures
- `k-kolomeitsev/data-structure-protocol` — graph-based memory for refactors
- `fockus/skill-memory-bank` — **file-based persistent project memory + engineering rules**

## What the skill provides

- **`.memory-bank/` directory** — `STATUS.md`, `plan.md`, `checklist.md`, `RESEARCH.md`, `progress.md` (append-only), `lessons.md`, `notes/`, `plans/`, `experiments/`, `reports/`, `codebase/`
- **Engineering rules bundled** — TDD, SOLID, DRY, KISS, YAGNI, Clean Architecture (backend), FSD (frontend), Mobile UDF (iOS/Android), Testing Trophy
- **18 slash commands** — `/mb`, `/plan`, `/start`, `/done`, `/verify`, `/review`, `/security-review`, `/commit`, `/pr`, `/adr`, `/contract`, `/api-contract`, `/db-migration`, `/observability`, `/refactor`, `/test`, `/doc`, `/changelog`, `/catchup`
- **`mb-codebase-mapper` subagent** — populates `.memory-bank/codebase/` with `STACK.md`, `ARCHITECTURE.md`, `CONVENTIONS.md`, `CONCERNS.md` so downstream agents have a grounded view of the repo
- **Stack auto-detect** via `mb-metrics.sh` across Python, Go, Rust, Node, Java, Kotlin, Ruby, .NET, C++, PHP, C#, Elixir, multi

## Cross-agent support

Works out of the box with: **Claude Code · Cursor · Windsurf · Cline · Kilo · OpenCode · Pi Code · Codex**. Single `install.sh` writes the adapters, skill aliases, hooks, and `AGENTS.md` managed blocks idempotently.

## Quality signals

- **Distributed** via PyPI (`pipx install memory-bank-skill`), Homebrew tap (`brew install fockus/tap/memory-bank`), skills.sh CLI (`npx skills add fockus/skill-memory-bank`), and git clone
- **MIT license**, Python 3.11+
- **SKILL.md** follows the open standard with `name: memory-bank` + `description`
- **CI-validated** — bats + pytest + shellcheck, PyPI Trusted Publishing, 92 %+ coverage on core scripts
- **Current release**: `v3.0.1` (stable, 2026-04-21)
- **Tested** with 14+ historic installs across real projects

## Build verification

Change is markdown-only (one bullet in the Context Engineering `<details>` block). I skipped running `npm run build` inside `website/` locally because the content of the Next.js site appears to be driven from separate data files under `website/src/` rather than the root `README.md`, so this one-line addition shouldn't regress the build. Happy to run it if the maintainers prefer — let me know.

## Format compliance

- [x] Entry format matches existing lines: `- [owner/repo](url) - Description`
- [x] Placed in correct category (Context Engineering)
- [x] Description is one line, non-promotional, technical
- [x] All links resolve
- [x] One item per PR