### PR TITLE
Add SSH ~ Api skills listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [vibheksoni/ssh-api](https://github.com/vibheksoni/ssh-api/tree/main/skills) - Agent-ready SSH and VPS automation skills for using a structured OpenAPI layer instead of raw SSH
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Add `vibheksoni/ssh-api` under Development and Testing.

Repo:
- https://github.com/vibheksoni/ssh-api

Why it fits:
- public GitHub repo with `skills/*/SKILL.md`
- focused on agent workflows
- teaches agents how to automate Linux VPS tasks through a structured OpenAPI layer instead of raw SSH

Current public skills:
- `ssh-api-setup`
- `ssh-api-vps-automation`