### PR TITLE
Add BlogBurst to Community Skills > Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
+- [shensi8312/blogburst-claude-skill](https://github.com/shensi8312/blogburst-claude-skill) - Autonomous social media manager for Twitter/Bluesky/Telegram/Discord — writes, posts, replies, and learns what works. Replaces a $500-1,500/mo freelance SMM
 </details>
 
 <details>


### PR DESCRIPTION
**BlogBurst** — Autonomous social media manager skill. Writes, posts, and replies on Twitter, Bluesky, Telegram, Discord. Replaces a $500-1500/mo freelance SMM for $29-99/mo. Public API endpoints let Claude demo real content before signup. Repo: https://github.com/shensi8312/blogburst-claude-skill

Added alphabetically-appropriate row under Community Skills > Marketing.