### PR TITLE
Add unslop to Community Skills (Marketing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [MohamedAbdallah-14/unslop](https://github.com/MohamedAbdallah-14/unslop) - MCP server and CLI skill that removes named AI writing patterns: tricolons, em-dash overuse, hedging stacks, sycophancy openers, and overused vocab. Lint-only audit mode, five intensity levels.
 </details>
 
 <details>


### PR DESCRIPTION
Adds unslop to the Marketing community skills section.

Unslop (https://github.com/MohamedAbdallah-14/unslop) removes named AI writing tells — tricolons, em-dash pileups, hedging stacks, sycophancy openers, stock vocabulary (look at, important, etc.). It has a split lint/rewrite architecture: the detection-only mode audits text without auto-rewriting, so you can review before committing changes. Five intensity levels. Works as a Claude Code plugin and as a standalone CLI. MIT licensed.

Placed after beautiful_prose in the Marketing section since it targets the same audience — people who want writing that doesn't read as AI-generated.