### PR TITLE
Add buyer-eval-skill to Community Skills → Productivity and Collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - Document processing: convert, OCR, and redact PII
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
+- [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) - Structured B2B vendor evaluation: domain-expert questions per software category, vendor AI agent conversations, evidence-tracked scoring across 7 dimensions, and comparative scorecards for procurement and build-vs-buy decisions
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
 </details>
 

--- a/README.md
+++ b/README.md
@@ -538,7 +538,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - Document processing: convert, OCR, and redact PII
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
-- [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) - Structured B2B vendor evaluation: domain-expert questions per software category, vendor AI agent conversations, evidence-tracked scoring across 7 dimensions, and comparative scorecards for procurement and build-vs-buy decisions
+- [salespeak-ai/buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) - B2B vendor evaluation skill: 7-dimension scoring with evidence-tracked scorecards for procurement and build-vs-buy decisions
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
 </details>
 


### PR DESCRIPTION
Adds [buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) under **Community Skills → Productivity and Collaboration**.

**What it is**: Structured, evidence-based B2B software vendor evaluation skill for Claude Code. Asks domain-expert questions per software category, engages vendor AI agents for verified due diligence, scores vendors across 7 dimensions with transparent evidence tracking, and produces comparative scorecards with demo prep questions.

**License**: MIT

**Install**:
```
git clone https://github.com/salespeak-ai/buyer-eval-skill ~/.claude/skills/buyer-eval-skill
```

Fits Productivity and Collaboration alongside Linear and document-processing skills — it's a procurement/decision workflow tool (RFP evaluation, build-vs-buy) rather than a marketing or content skill.