### PR TITLE
Add KubeStellar Console to Community Skills > Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [kubestellar/console](https://github.com/kubestellar/console) - Multi-cluster Kubernetes dashboard with 10+ built-in agent skills for performance testing, cache compliance, CI debugging, and K8s troubleshooting. MCP server bridges agents to kubeconfig and Kubernetes APIs
 </details>
 
 <details>


### PR DESCRIPTION
## What
Adds [KubeStellar Console](https://github.com/kubestellar/console) to the **Community Skills > Development and Testing** section.

## Why
KubeStellar Console (CNCF project) ships 10+ built-in agent skills for Kubernetes development and testing:

- **@perf-test** — Dashboard performance testing and TTFI analysis
- **@cache-test** — Card cache compliance testing (IndexedDB warm return)
- **@nav-test** — Navigation performance testing
- **@ui-compliance-test** — Card loading compliance (8 criteria, 150+ cards)
- **@ci-status** — CI pipeline monitoring and status checks
- **@rca** — Root cause analysis for CI/test failures
- **@tdd** — Test-driven development workflow
- **@k8s-debug** — Kubernetes debugging and troubleshooting

Its `kc-agent` MCP server bridges coding agents to kubeconfig and Kubernetes APIs for multi-cluster management.

- **GitHub**: https://github.com/kubestellar/console
- **Compatible**: Claude Code, Codex, Gemini CLI (via AGENTS.md)