### PR TITLE
Add tianluo to Context Engineering: methodology for long-running autonomous runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
+- [yeewangcn/tianluo](https://github.com/yeewangcn/tianluo) - Methodology for multi-hour autonomous runs. State survives context compaction, plan-time fork enumeration, 5-layer diagnosis, budget-bounded retry. Bilingual EN/CN
 </details>
 
 ---


### PR DESCRIPTION
Adds **tianluo (田螺姑娘)** — a methodology skill for keeping AI coding assistants on a multi-hour task without pinging the operator at 3am for routine confirmations.

Five concrete capabilities, each inverting one specific multi-hour-agent failure mode:

1. **Persistent state survives context compaction** — state.json + self-contained cron prompts that rebuild context from scratch every wake-up
2. **Plan-time fork enumeration** — every future user-decision listed as Q1..Qn before the run starts, answered once, then zero further interruptions
3. **5-layer structured diagnosis** — scheduler / container / log / progress / output
4. **Budget-bounded retry with escalation ladder** — transient → patch → replan → human; never retry a code-level bug
5. **File-role strict separation** — state.json / plan.md / failures/*.md / memory/*.md never merged

Adding under **Community Skills > Context Engineering** since the central insight — cron prompts that rebuild context from scratch every wake-up + agent never re-reading its own plan as runtime ground truth — is fundamentally a context-engineering claim. Adjacent to context-compression and memory-systems entries.

Repo: https://github.com/yeewangcn/tianluo
License: MIT
Bilingual EN/CN README and case study (matches this list's multilingual stance).
Compatible with Claude Code (native plugin install) and any agent that can read Markdown rules / system prompts (Codex, Cursor, Aider, Continue, Gemini CLI, Copilot, OpenCode, Windsurf — clone-and-reference).