### PR TITLE
Add Kavach skill (new Authorization and Access subsection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,9 @@ Comprehensive SaaS marketing stack skills by [Corey Haines](https://github.com/c
 
 ### Security & Web Intelligence
 
+#### Authorization and Access
+- [SarthiAI/kavach-skill](https://github.com/SarthiAI/kavach-skill) - Default-deny execution gate for AI agents and APIs (post-quantum signed permits, drift detection, audit chain), Python SDK on PyPI
+
 #### Skills by Trail of Bits
 - [trailofbits/audit-context-building](https://agent-skill.co/trailofbits/skills/audit-context-building) - Deep architectural context via granular code analysis
 - [trailofbits/building-secure-contracts](https://agent-skill.co/trailofbits/skills/building-secure-contracts) - Smart contract security toolkit for 6 blockchains


### PR DESCRIPTION
Adds Kavach under a new `Authorization and Access` subsection at the top of `Security & Web Intelligence`. The existing subsections in that section are organized by team (Trail of Bits, Sentry, Firecrawl, Microsoft); a category-level subsection like `Authorization and Access` gives a clear home for skills in the access-control space (this one and any future contributions in the same area), without each new contributor needing their own per-org subsection.

Kavach is a default-deny execution gate for AI agents, APIs, and distributed systems. It runs identity, policy, drift, and invariant checks on every action and produces a post-quantum signed permit any downstream service can verify. The skill teaches AI coding agents how to integrate the published `kavach-sdk` library (Python, on PyPI) into a real service: policy authoring, drift wiring, signed permits, audit chain, secure channel, observe-mode rollout.

Skill repo: https://github.com/SarthiAI/kavach-skill (Apache-2.0)
Library repo: https://github.com/SarthiAI/Kavach (Elastic License 2.0)
Install: `npx skills add SarthiAI/kavach-skill`
Validates with `skills-ref validate`. Compatible with Claude Code, Cursor, Codex, Gemini CLI, and any client that reads `SKILL.md`.