### PR TITLE
feat: add BuyWhere product catalog API and MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [BuyWhere/buywhere-api](https://github.com/BuyWhere/buywhere-api) - Agent-native product catalog API and MCP server for real-time multi-platform commerce search, price comparison, and deal discovery across 1,000+ merchants
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Add [BuyWhere/buywhere-api](https://github.com/BuyWhere/buywhere-api) to the Community Skills > Development and Testing section.

BuyWhere is an agent-native product catalog API and MCP server that provides real-time multi-platform commerce search, price comparison, and deal discovery across 1,000+ merchants (Shopee, Lazada, Amazon SG, Walmart, and more). It supports MCP protocol integration for AI agents to query product data directly.

- **Category**: Community Skills > Development and Testing
- **Format**: Standard bullet entry with repo link and description
- **Verified**: Entry follows existing convention in the section