### PR TITLE
Add jaxx2104/exiftool-skill to Productivity and Collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [jaxx2104/exiftool-skill](https://github.com/jaxx2104/exiftool-skill) - View, edit, geotag, and sanitize image/video metadata via ExifTool
 </details>
 
 <details>


### PR DESCRIPTION
Adds [jaxx2104/exiftool-skill](https://github.com/jaxx2104/exiftool-skill) to **Community Skills → Productivity and Collaboration**.

A Claude Code Agent Skill that translates natural-language requests into safe ExifTool invocations across image, video, and audio files: view metadata, GPS read/write/strip, capture-date and timezone correction, sidecar XMP, batch rename, JSON/CSV export, video metadata (GoPro, DJI, QuickTime), and pre-publication sanitize. Write/delete operations are gated by a plan → confirm → execute pattern with explicit `_original` backup handling. Sits next to [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) (document processing / PII redaction) — same shape, media metadata flavor.

- Repo: https://github.com/jaxx2104/exiftool-skill
- Install: `/plugin marketplace add jaxx2104/exiftool-skill` then `/plugin install exiftool@jaxx2104`
- License: same as upstream ExifTool (Artistic-1.0-Perl OR GPL-1.0-or-later)
- Has SKILL.md ✅, public repo ✅, author/org prefix in name ✅