### PR TITLE
Add Bring Your AI migration auditor skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
+- [unitedideas/bringyour-migration-auditor](https://github.com/unitedideas/bringyour-mcp/tree/main/skills/bringyour-migration-auditor) - Audit Claude Code to Codex migrations for instruction scope, hooks, MCP config, skills, secrets, and validation notes
 </details>
 
 ---


### PR DESCRIPTION
## Summary
- Adds the public Bring Your AI migration-auditor SKILL.md to Context Engineering.
- The skill helps agents audit Claude Code to Codex migrations for instruction scope, hooks, MCP config, skills, secrets, and validation notes.

## Verification
- Confirmed no existing Bring Your AI, bringyour, or migration-auditor entry in README.
- Verified the skill URL returns HTTP 200.
- Tried `npm run build` under `website/`; it could not run because `next` is not installed in the fresh clone.

## Checklist
- [x] Added metadata to README.md
- [x] Checked duplicate PRs/issues before submitting
- [x] Kept the change to one community skill entry