### PR TITLE
Add companion-memory skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
+- [zhyue365/companion-memory](https://github.com/zhyue365/companion-memory) - Local-first Codex relationship memory plugin
 </details>
 
 ---


### PR DESCRIPTION
Adds companion-memory to the Context Engineering community skills section.\n\ncompanion-memory is a local-first Codex relationship memory plugin/skill bundle with MCP stdio tools, SQLite + FTS5/vector recall, sensitive recall opt-in, and dry-run forgetting.