### PR TITLE
Add mbti-parallel-persona: MBTI personality companion skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [taiyouZhang/mbti-parallel-persona](https://github.com/taiyouZhang/mbti-parallel-persona) - MBTI personality companion — responds to life in your chosen type's voice, short and emotionally on point
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

- Add [taiyouZhang/mbti-parallel-persona](https://github.com/taiyouZhang/mbti-parallel-persona) to Community Skills > Productivity and Collaboration

## What it does

MBTI personality companion — responds to life in your chosen type's voice, short and emotionally on point.

- Trigger: `/mbti` (explicit only, never auto-activates)
- 16 types with multiple situational nicknames per type
- Contrast mode (`/mbti all`): 4 types from different groups respond simultaneously
- Flexible switching via type name, nickname, or natural language mention
- Follows SKILL.md standard with references and scripts

## Quality Standards

- [x] Clear instructions in SKILL.md
- [x] Appropriate scope: one focused task (emotional companion)
- [x] Working examples with multiple scenarios
- [x] SKILL.md under 500 lines