### PR TITLE
Add AgentGuard — runtime guardrails for AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,9 @@ Official skills for ML workflows.
 
 ### Developer Tools & Frameworks
 
+#### Skill by AgentGuard
+- [bmdhodl/agent47](https://github.com/bmdhodl/agent47) - Runtime budget, token, rate, and timeout guardrails for AI coding agents. Stops loops, retry storms, and overruns mid-run. MIT, zero deps, local-first.
+
 #### Skills by VoltAgent
 - [voltagent/create-voltagent](https://agent-skill.co/voltagent/skills/create-voltagent) - Project setup guide with CLI and manual steps
 - [voltagent/voltagent-best-practices](https://agent-skill.co/voltagent/skills/voltagent-best-practices) - Architecture and usage patterns for agents, workflows, memory, and servers


### PR DESCRIPTION
## Summary
- Add AgentGuard to Developer Tools & Frameworks.
- Link to the public bmdhodl/agent47 repo, which includes `skills/agentguard/SKILL.md`.

## Validation
- `gh skill publish --dry-run` passes in bmdhodl/agent47.
- `npx skills add K:\agent47` installs `agentguard` from the spec-native skill path locally.
- `python -m venv .venv && pip install agentguard47` confirms PyPI `1.2.10` and `agentguard doctor` succeeds.
- `npm ci && npm run build` passes in `website/`.