### PR TITLE
Add Xquik x-twitter-scraper skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,9 @@ Comprehensive SaaS marketing stack skills by [Corey Haines](https://github.com/c
 - [firecrawl/firecrawl-agent](https://agent-skill.co/firecrawl/skills/firecrawl-agent) - AI agent for autonomous web scraping
 - [firecrawl/firecrawl-browser](https://agent-skill.co/firecrawl/skills/firecrawl-browser) - Browser-based web scraping and interaction
 
+#### Skill by Xquik
+- [x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data skill for tweet search, profile timelines, follower export, media download, monitors, webhooks, MCP, and SDK workflows
+
 <details>
 <summary><strong>Skills by Microsoft</strong></summary>
 


### PR DESCRIPTION
## Summary
- Add the Xquik `x-twitter-scraper` agent skill to Security & Web Intelligence.
- Link the public skill repository and describe source-backed X/Twitter data workflows.

## Duplicate checks
- Searched the default branch for `Xquik`, `x-twitter-scraper`, `xquik.com`, and `TweetClaw`: no matches.
- Searched open and closed PRs/issues for the same names and URLs: no matches.

## Validation
- `git diff --check`
- `npm --prefix website ci`
- `npm --prefix website run build`
- Verified `https://github.com/Xquik-dev/x-twitter-scraper` returns HTTP 200.
