### PR TITLE
feat: add Finance & Investment community skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,6 +533,13 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 </details>
 
 <details>
+<summary><strong>Finance & Investment</strong></summary>
+
+- [tellmefrankie/news-engine](https://github.com/tellmefrankie/news-engine) - 4 production-tested investment analysis skills: options flow scanner with P/C ratio anomaly detection, stop-loss monitor with Telegram alerts, 9-wave daily briefing, portfolio Greeks dashboard. MIT, TypeScript + Claude API.
+
+</details>
+
+<details>
 <summary><strong>Productivity and Collaboration</strong></summary>
 
 - [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - Document processing: convert, OCR, and redact PII


### PR DESCRIPTION
## What this adds

New community category: **Finance & Investment**

**[tellmefrankie/news-engine](https://github.com/tellmefrankie/news-engine)** — 4 production-tested Claude Code skills for investment analysis:
- Options flow scanner with P/C ratio anomaly detection (caught XLI at 5.32, 4x above baseline)
- Stop-loss monitor with Telegram alerts (real-time price threshold crossing)
- 9-wave daily investment briefing (macro → options → sentiment → technicals → risk → opportunities → alerts → trade ideas → execution)
- Portfolio Greeks dashboard (concentration risk, leverage tracking)

Built with TypeScript + Claude API + SQLite. MIT licensed. Running on a real portfolio for 6 months.

## Why Finance deserves its own section

No existing finance/investment category in the community skills section. This is a distinct domain (real-time market data, options analysis, portfolio management) that doesn't fit under Development, Productivity, or Marketing.

## Links

- Source: https://github.com/tellmefrankie/news-engine
- Write-up: https://dev.to/tellmefrankie/when-the-market-whispers-through-sector-etfs-the-xli-pc-532-signal-14l8