### PR TITLE
Add Finance section with ai-investment-skills — options flow scanner + price monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,12 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 </details>
 
 <details>
+<summary><strong>Finance and Investment</strong></summary>
+
+- [tellmefrankie/ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills) - Options flow scanner with volume quality filtering, stop-loss/take-profit price monitor with Telegram alerts, and daily AI briefing. Detects sector ETF P/C ratio anomalies (e.g., XLI P/C at 5.32 vs. normal 0.5–1.2).
+</details>
+
+<details>
 <summary><strong>Context Engineering</strong></summary>
 
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions


### PR DESCRIPTION
## Summary

Adds a new **Finance and Investment** section to Community Skills with [ai-investment-skills](https://github.com/tellmefrankie/ai-investment-skills).

**Skills included:**
- Options flow scanner — detects unusual sector ETF P/C ratios, filters low-quality volume (lottery tickets inflate raw P/C, creating false signals)
- Stop-loss/take-profit price monitor — Telegram alerts, checks every 5 min during pre-market/regular/after-hours
- Daily AI briefing — morning market context

**Real signal caught:**
XLI P/C hit 5.32 (normal: 0.5–1.2). After filtering 98% lottery volume: "extremely bearish." Raw said "neutral." That difference is the value of the quality filtering.

**Free, open source (MIT license).** SKILL.md format, compatible with Claude Code, Codex, Gemini CLI, and more.