### PR TITLE
add authsome under Business, Productivity &amp; Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ Official skills for ML workflows.
 - [composiohq/composio](https://agent-skill.co/composiohq/skills/composio) - Connect AI agents to 1000+ external apps with managed authentication
 
 #### Skills by Authsome
-- [manojbajaj95/authsome](https://github.com/manojbajaj95/authsome) - Local OAuth2 and API-key credential broker for AI agents. Login once via browser PKCE or device code, encrypted vault at ~/.authsome, local proxy injects credentials at request time. 30+ providers preconfigured.
+- [agentrhq/authsome](https://github.com/agentrhq/authsome) - Local OAuth2 and API-key credential broker for AI agents. Login once via browser PKCE or device code, encrypted vault at ~/.authsome, local proxy injects credentials at request time. 30+ providers preconfigured.
 
 #### Skills by Notion
 - [makenotion/knowledge-capture](https://agent-skill.co/makenotion/skills/knowledge-capture) - Transform conversations into structured Notion documentation

--- a/README.md
+++ b/README.md
@@ -325,6 +325,9 @@ Official skills for ML workflows.
 #### Skills by Composio
 - [composiohq/composio](https://agent-skill.co/composiohq/skills/composio) - Connect AI agents to 1000+ external apps with managed authentication
 
+#### Skills by Authsome
+- [manojbajaj95/authsome](https://github.com/manojbajaj95/authsome) - Local OAuth2 and API-key credential broker for AI agents. Login once via browser PKCE or device code, encrypted vault at ~/.authsome, local proxy injects credentials at request time. 30+ providers preconfigured.
+
 #### Skills by Notion
 - [makenotion/knowledge-capture](https://agent-skill.co/makenotion/skills/knowledge-capture) - Transform conversations into structured Notion documentation
 - [makenotion/meeting-intelligence](https://agent-skill.co/makenotion/skills/meeting-intelligence) - Prepare meeting materials by gathering Notion context


### PR DESCRIPTION
hey, opening this to add authsome under Business, Productivity & Marketing, right next to the Skills by Composio block. it's the local-first peer to Composio's managed-auth approach.

authsome is a local OAuth2 and API-key credential broker for AI agents. login once via browser PKCE or device code, credentials live in an encrypted vault at ~/.authsome, and a local proxy injects them at request time so the agent's process env never holds raw keys. 30+ providers preconfigured (github, google, openai, linear, slack, notion, resend, stripe, etc).

ships an agentskills.io-compatible SKILL.md at https://github.com/agentrhq/authsome/tree/main/skills/authsome. standalone CLI installs via `uvx authsome@latest` or `pip install authsome`.

happy to reword the entry or move it (Developer Tools & Frameworks would be a reasonable alternative). flagged as a new `#### Skills by Authsome` block to match the format the rest of the section uses.

repo: https://github.com/agentrhq/authsome
license: MIT
pypi: https://pypi.org/project/authsome/
