### PR TITLE
Add mturac/recsys-pipeline-architect (Community Skills · Development and Testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [mturac/recsys-pipeline-architect](https://github.com/mturac/recsys-pipeline-architect) - Designs composable recommendation, ranking, and feed pipelines via the six-stage Source→Hydrator→Filter→Scorer→Selector→SideEffect framework. Runnable scaffolds for Strapi (TypeScript), Go, and Python/FastAPI
 </details>
 
 <details>


### PR DESCRIPTION
Adds [recsys-pipeline-architect](https://github.com/mturac/recsys-pipeline-architect) — a vendor-agnostic Agent Skill (agentskills.io standard) for designing composable recommendation, ranking, and feed pipelines using the six-stage **Source → Hydrator → Filter → Scorer → Selector → SideEffect** framework popularized by xAI's open-sourced [For You algorithm](https://github.com/xai-org/x-algorithm). MIT, independent reimplementation of the pattern.

Compatible with Claude Code, Codex CLI, Cursor, Gemini CLI, and more via `npx skills add mturac/recsys-pipeline-architect`.

Repo: SKILL.md + 5 reference docs + 3 runnable example scaffolds (Strapi/TS, Go, Python/FastAPI — 9/9 tests passing). v0.1.0 release tagged.

Inserted into the *Development and Testing* sub-section of *Community Skills*.