### PR TITLE
docs: add Sequenzy email marketing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 
 - [BrianRWagner/ai-marketing-skills](https://github.com/BrianRWagner/ai-marketing-skills) - 17 marketing frameworks for outreach and audits
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
+- [Sequenzy Email Marketing Skill](https://github.com/Sequenzy/skills/tree/main/skills/sequenzy-email-marketing) - Operate Sequenzy email marketing and transactional/product email workflows from AI agents
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
 </details>


### PR DESCRIPTION
Adds the Sequenzy Email Marketing skill to the community Marketing skills section.