### PR TITLE
Add polis-protocol to Productivity and Collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [yehudalevy-collab/polis-protocol](https://github.com/yehudalevy-collab/polis-protocol) - Markdown coordination protocol for multi-vendor agent teams. Capability cards, ε-greedy bandit routing that learns from settled contracts, chavruta paired review, self-amending constitution
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adds **polis-protocol** to **Community Skills → Individual Skills**.

## What it is

A markdown-only coordination protocol for multi-vendor agent teams:

- **Signed capability cards** per citizen
- **ε-greedy multi-armed bandit routing** that learns from settled-contract outcomes
- **Chavruta paired review** for high-stakes contracts
- **Self-amending constitution** via a ratifiable amendment process

Vendor-agnostic — works across Claude Code, Codex, Gemini CLI, and any markdown-capable agent. MIT licensed.

Worked example with 3 citizens, a leader-shift on a tag after a real lesson, and a ratified amendment: [examples/research-team/](https://github.com/yehudalevy-collab/polis-protocol/tree/main/examples/research-team)

Repo: https://github.com/yehudalevy-collab/polis-protocol
