### PR TITLE
Add Bilig WorkPaper agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 <summary><strong>Productivity and Collaboration</strong></summary>
 
 - [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - Document processing: convert, OCR, and redact PII
+- [proompteng/bilig](https://github.com/proompteng/bilig/tree/main/skills/bilig-workpaper) - Formula WorkPaper skill and MCP server for agents: edit spreadsheet cells through an API, recalculate formulas, verify readback, and persist JSON without driving Excel UI.
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams


### PR DESCRIPTION
## Summary
Add Bilig WorkPaper to the Productivity and Collaboration community skills section.

Bilig gives agents a formula-backed WorkPaper skill and MCP server for spreadsheet-style models: edit cells through an API, recalculate formulas, verify readback, and persist JSON without driving Excel UI.

## Fit
- Public SKILL.md at `skills/bilig-workpaper/SKILL.md`
- Works with Codex/Claude-style skill loading and includes MCP setup guidance
- Useful for spreadsheet automation, backend formula models, and agent workflows that need auditable workbook state

## Validation
- Checked this repository for existing Bilig/WorkPaper entries before adding this one
- Changed only the `README.md` community skill list
