### PR TITLE
Add Bilig WorkPaper agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 <summary><strong>Productivity and Collaboration</strong></summary>
 
 - [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - Document processing: convert, OCR, and redact PII
+- [proompteng/bilig WorkPaper skill](https://github.com/proompteng/bilig/blob/main/docs/.well-known/agent-skills/bilig-workpaper/SKILL.md) - Formula-backed workbook skill for agents: edit cells through MCP or TypeScript, recalculate formulas, verify readback, and persist JSON without driving spreadsheet UI.
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams


### PR DESCRIPTION
## Summary
Add Bilig WorkPaper to the Productivity and Collaboration community skills section.

Bilig gives agents a public `SKILL.md` plus MCP/TypeScript guidance for formula-backed workbook work: read sheets, edit cells through a narrow API, recalculate formulas, verify readback, and persist JSON without driving Excel or browser-grid UI.

## Fit
- Public skill manifest: https://github.com/proompteng/bilig/blob/main/docs/.well-known/agent-skills/bilig-workpaper/SKILL.md
- Public skill index: https://proompteng.github.io/bilig/.well-known/agent-skills/index.json
- Useful for agents handling pricing, quote approval, budgets, payout models, XLSX formula bugs, and other spreadsheet-shaped service logic.

## Duplicate check
- Repository search found no existing Bilig/WorkPaper entry.
- This replaces closed PR #241, which pointed at the wrong skill path and could not be reopened after the branch was restored.

## Validation
- Changed only `README.md`.
- Bilig repo discovery check passes with the linked skill path.
