### PR TITLE
feat: add video-debug skill under Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [vladzima/video-debug](https://github.com/vladzima/video-debug) - Debug UI bugs from screencasts by extracting key frames via ffmpeg scene detection
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adding [vladzima/video-debug](https://github.com/vladzima/video-debug) under the **Development and Testing** category.

## What the skill does

Lets coding agents (Claude Code, Codex, Cursor, etc.) "watch" a screencast to debug a UI bug. The skill runs locally, uses ffmpeg scene detection to extract only the frames where the screen actually changes, downscales them, and emits a structured markdown timeline. The agent then uses its native image-reading tool to visually inspect each frame and correlate the glitch with the relevant component in the user's codebase — citing the exact frame timestamp that evidenced the bug.

No new server, no new API key — just bash + ffmpeg.

## Quality checks

- [x] SKILL.md with valid YAML frontmatter (`name`, `description`, `allowed-tools`)
- [x] Single focused task: ffmpeg-based key-frame extraction for visual debugging
- [x] Honest about limitations (no audio transcription, no OCR, no smart deduplication — documented in README)
- [x] Working examples in README
- [x] Under 500 lines (SKILL.md is ~90 lines)
- [x] Tested with both synthetic videos (4 strategy paths) and a real screencast end-to-end through Claude Code
- [x] MIT licensed