### PR TITLE
Add: SocialClaw — multi-platform social media scheduling and publishing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,9 @@ Official skills for ML workflows.
 #### Skills by Typefully
 - [typefully/typefully](https://agent-skill.co/typefully/skills/typefully) - Create, schedule, and publish social media content
 
+#### Skills by SocialClaw
+- [ndesv21/socialclaw](https://github.com/ndesv21/socialclaw) - Schedule and publish social media posts across 13 platforms (X, LinkedIn, Instagram, Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, Pinterest) via a single workspace API key.
+
 #### Skills by Composio
 - [composiohq/composio](https://agent-skill.co/composiohq/skills/composio) - Connect AI agents to 1000+ external apps with managed authentication
 


### PR DESCRIPTION
Adds [SocialClaw](https://github.com/ndesv21/socialclaw) to the **Business, Productivity & Marketing → Skills by SocialClaw** section.

SocialClaw is an agent-first social publishing skill that connects Claude Code (and other agents) to 13 social media platforms through a single workspace API key: X, LinkedIn (profile + page), Instagram (Business + standalone), Facebook Pages, TikTok, Discord, Telegram, YouTube, Reddit, WordPress, and Pinterest.

**What it enables:**
- Schedule and publish posts across platforms from a single `schedule.json`
- Upload media assets, validate schedules before going live, and monitor run status
- No per-provider OAuth secrets exposed to the agent — accounts are connected via the SocialClaw dashboard

**Install:**
```bash
npx skills add ndesv21/socialclaw
```

- GitHub: https://github.com/ndesv21/socialclaw
- Dashboard: https://getsocialclaw.com
- License: MIT