### PR TITLE
feat: add LaunchMyStore skill (Business, Productivity & Marketing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,9 @@ Official skills for ML workflows.
 - [better-auth/create-auth](https://agent-skill.co/better-auth/skills/create-auth) - Create authentication setup with Better Auth
 - [better-auth/twoFactor](https://agent-skill.co/better-auth/skills/twoFactor) - Two-factor authentication with Better Auth
 
+#### Skills by LaunchMyStore
+- [LaunchMyStore/skill](https://github.com/LaunchMyStore/skill) - Natural-language router for the LaunchMyStore e-commerce platform. Scaffold apps with the `lms` CLI, dispatch App Bridge actions, build WASM Functions (cart transform / discount / shipping / payment / delivery / order validation), write Aqua/Liquid theme sections, and drive the LaunchMyStore MCP server (130+ merchant-store tools). Universal SKILL.md install across Claude Code, Codex, Cursor, Gemini CLI, Windsurf, Antigravity, and more.
+
 <details>
 <summary><strong>Marketing Skills by Corey Haines</strong></summary>
 


### PR DESCRIPTION
Adds **LaunchMyStore** under "Business, Productivity & Marketing" (after Better Auth, before the Marketing Skills details block).

**What the skill does** — natural-language router for the [LaunchMyStore](https://launchmystore.io) e-commerce platform:
- Scaffolds apps with the `lms` CLI
- Dispatches App Bridge actions (Toast, Modal, ResourcePicker, SessionToken, etc.)
- Builds WASM Functions — all 6 types (cart transform / discount / shipping / payment / delivery / order validation)
- Writes Aqua / Liquid theme sections, blocks, snippets
- Drives the LaunchMyStore MCP server (130+ merchant-store tools)

**Universal SKILL.md compatibility** — works in Claude Code, OpenAI Codex, Cursor, Gemini CLI, Windsurf, Antigravity, Aider, OpenCode, OpenClaw, Kilo Code, Augment, Hermes Agent, Mistral Vibe.

- Repo: https://github.com/LaunchMyStore/skill
- npm: `@launchmystore/claude-skill` (v1.1.1)
- Install: `npx skills add LaunchMyStore/skill`
- License: MIT
