### PR TITLE
Add Pluribus context receipts skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
+- [caioribeiroclw-pixel/pluribus/context-receipts](https://github.com/caioribeiroclw-pixel/pluribus/tree/main/examples/agent-skills/context-receipts) - Privacy-safe receipts for context usage, Tool Search, subagent boundaries, compaction, and pruning
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
 </details>
 


### PR DESCRIPTION
Adds Pluribus' Context Receipts skill to the Context Engineering section.\n\nWhy it fits:\n- It is a standard SKILL.md with metadata frontmatter.\n- It focuses on a narrow context-engineering workflow: privacy-safe receipts for what entered context, stayed deferred, crossed subagent boundaries, or was pruned/compacted.\n- It includes concrete smoke shapes for Tool Search, skill loading, usage attribution, subagent boundaries, pruning, and compaction transaction safety.\n\nVerification:\n- `git diff --check`\n- confirmed the GitHub directory link resolves\n- confirmed the raw SKILL.md starts with `name: context-receipts` frontmatter\n- no website/package.json build target is present in this checkout