### PR TITLE
Add Sematext skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,9 @@ Official skills for ML workflows.
 - [figma/figma-generate-library](https://agent-skill.co/figma/skills/figma-generate-library) - Build or update a design system library in Figma from a codebase
 - [figma/figma-use](https://agent-skill.co/figma/skills/figma-use) - Run Figma Plugin API scripts for canvas writes and inspections
 
+#### Skills by Sematext
+- [sematext/sematext-otel-skills](https://github.com/sematext/sematext-otel-onboarding/tree/main/skills) - Instrument applications with OpenTelemetry SDK and ship traces, logs, and metrics to Sematext
+
 ---
 
 ### Google Ecosystem


### PR DESCRIPTION
This skills makes it easy to instrument an application with OpenTelemetry SDK and configure the SDK to ship OpenTelemetry signals (traces, logs, and metrics) to Sematext