### PR TITLE
Add docs-to-book skill (Productivity and Collaboration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [EliaTolin/docs-to-book-skills](https://github.com/EliaTolin/docs-to-book-skills) - Turn online technical docs into a colorful, readable PDF book translated into any language
 </details>
 
 <details>


### PR DESCRIPTION
## What this adds

Adds **[docs-to-book](https://github.com/EliaTolin/docs-to-book-skills)** to **Community Skills → Productivity and Collaboration**.

A Claude Code skill that turns online technical documentation into a colorful, readable PDF book, translated into the language of your choice. It crawls the docs, extracts and rewrites the content into book form, applies a brand-aware Typst theme (with a trademark guardrail on palette extraction), and compiles a polished PDF.

## Placement

`Community Skills → Productivity and Collaboration` — alongside existing document-processing / docs-transformation skills (e.g. `nutrient-agent-skill`, `tutor-skills`). The Table of Contents already links this subsection, so no ToC change is needed.

## Quality standards

- **Self-contained `SKILL.md`** under 500 lines, with clear When-to-Use triggers and step-by-step instructions for the agent.
- **More than a single file**: ships `scripts/` (crawl, extract, brand extraction, compile), `references/` (crawling strategy, tone guide, integrity rules, Typst callouts), `assets/` (Typst styles + cover), and `evals/`.
- **License**: MIT.

## Notes

- Change is a single README entry (link to an externally-hosted repo, per the index convention) — no `website/` source files were touched.