### PR TITLE
Add ZeroPointRepo/youtube-skills to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [ZeroPointRepo/youtube-skills](https://github.com/ZeroPointRepo/youtube-skills) - YouTube transcripts, search, channel data, and playlists via TranscriptAPI. Works anywhere.
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adds [ZeroPointRepo/youtube-skills](https://github.com/ZeroPointRepo/youtube-skills) to Community Skills.

- Transcript extraction (with timestamps), video search, channel browsing, in-channel search, playlist extraction, and upload monitoring
- TranscriptAPI processes 500K+ transcripts daily, fast. Works from cloud servers. Zero credits on failed calls.
- 223 stars, MIT licensed, no yt-dlp · 686 installs via the `skills` CLI (skills.sh/zeropointrepo/youtube-skills)

```bash
npx skills add ZeroPointRepo/youtube-skills --skill youtube-full
```

100 free credits on install.
