### PR TITLE
feat: add Finance & Investment skills + doc2math to Context Engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,8 +557,16 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
+- [thebrierfox/doc2math-skill](https://github.com/thebrierfox/doc2math-skill) - Formalize prose documents into precise mathematical notation for rigorous analysis and verification
 </details>
 
+
+<details>
+<summary><strong>Finance & Investment</strong></summary>
+
+- [thebrierfox/yield-intelligence-skill](https://github.com/thebrierfox/yield-intelligence-skill) - Live Treasury rates, passive income portfolio calculator, and AI analyst for yield allocation decisions
+- [thebrierfox/moatmri-skill](https://github.com/thebrierfox/moatmri-skill) - AI disruption pressure analysis: identify economic moats under threat and quantify competitive risk exposure
+</details>
 ---
 
 ## Skill Quality Standards


### PR DESCRIPTION
## What this adds

**New section: Finance & Investment**

- [`thebrierfox/yield-intelligence-skill`](https://github.com/thebrierfox/yield-intelligence-skill) — Live Treasury rates, passive income portfolio calculator, and AI analyst for yield allocation decisions. Follows the SKILL.md standard.

- [`thebrierfox/moatmri-skill`](https://github.com/thebrierfox/moatmri-skill) — AI disruption pressure analysis: identify economic moats under threat and quantify competitive risk exposure.

**Existing section: Context Engineering**

- [`thebrierfox/doc2math-skill`](https://github.com/thebrierfox/doc2math-skill) — Formalize prose documents into precise mathematical notation for rigorous analysis and verification.

## Quality checklist
- All skills follow the SKILL.md standard
- Public repos, actively maintained
- Descriptions are concise and specific