### PR TITLE
feat: add UnifAPI KOL pricing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
+- [unifapi-agent/kol-pricing](https://github.com/unifapi-agent/skills/tree/main/skills/kol-pricing) - Price creator campaigns with public social data
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adds the UnifAPI KOL pricing skill to the Community Skills > Marketing section.

## Validation

- Verified the skill URL returns HTTP 200.
- Ran `git diff --check`.
- Ran `npm ci` and `npm run build` in `website/`.
