### PR TITLE
Add OneQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
-- [wordbricks/onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - Agent-ready CLI skill for governed data-source queries
+- [wordbricks/onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - CLI skill for safe, auditable agent queries against approved data sources
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
-- [wordbricks/onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - CLI skill for safe, auditable agent queries against approved data sources
+- [wordbricks/onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - CLI skill for safe, auditable queries for agents against approved data sources
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [wordbricks/onequery-cli](https://github.com/wordbricks/skills/tree/main/skills/onequery-cli) - Agent-ready CLI skill for governed data-source queries
 </details>
 
 <details>


### PR DESCRIPTION
Adds wordbricks/onequery-cli to Community Skills / Development and Testing.

OneQuery CLI is a skill for safe, auditable queries for agents against approved data sources.

Guideline check:
- Public skill link with SKILL.md documentation.
- Description is brief and follows the list format.
- Link works and no duplicate OneQuery entry was found before submission.
- Disclosure: I am affiliated with Wordbricks/OneQuery.