### PR TITLE
Add CheckYourself and Web Typography skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [KyaniteLabs/checkyourself](https://github.com/KyaniteLabs/checkyourself/tree/main/skills/checkyourself) - Production-readiness diagnostics for AI-built apps
 </details>
 
 <details>
@@ -549,6 +550,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [simongonzalezdc/web-typography-skill](https://github.com/simongonzalezdc/web-typography-skill) - Web typography workflow for readable front-end text
 </details>
 
 <details>


### PR DESCRIPTION
Adds two community SKILL.md resources: CheckYourself for production-readiness diagnostics and Web Typography Skill for readable front-end typography workflows.

Verification:
- npm install (website)
- npm run build (website)