### PR TITLE
Add Commerce and Payments category with AWM (AI Work Market)

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,14 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
 </details>
 
+<details>
+<summary><strong>Commerce and Payments</strong></summary>
+
+- [darioandyoshi-tech/awm-skills](https://github.com/darioandyoshi-tech/awm-skills) - AI Work Market (AWM): USDC escrow for AI agent work contracts on Base Mainnet. Complements x402 (atomic pay-per-call) with multi-day proof + dispute + release. 1% fee, Safe + Timelock governance.
+- [inference-sh/skills](https://github.com/inference-sh/skills) - 250+ AI model and tool skills via the inference.sh CLI (image, video, LLMs, search)
+- [Merit-Systems/awesome-agentic-commerce](https://github.com/Merit-Systems/awesome-agentic-commerce) - Curated agent commerce resources, x402, USDC, MPC wallets
+</details>
+
 ---
 
 ## Skill Quality Standards


### PR DESCRIPTION
Hi Hailey — adding a new 'Commerce and Payments' category to the Agent Skill Index. AWM (AI Work Market) is the headline addition: a deployed USDC escrow for agent work contracts on Base Mainnet that complements x402 (which the index doesn't yet cover). Also adds inference-sh/skills and Merit-Systems/awesome-agentic-commerce as adjacent references.

AWM repo: https://github.com/darioandyoshi-tech/awm-skills
- Live at: https://ai-work-market.ai
- SKILL.md follows the standard at skills/ai-work-market/SKILL.md
- 1% fee, USDC, Base Mainnet, Safe + 48h Timelock governance
- 4 work contracts on mainnet (3 completed, 1 disputed-and-resolved)
- MCP server at /mcp with 8 tools

The existing 5 categories (Vector DBs, Marketing, Productivity, Dev & Testing, Context Engineering) are great — commerce/payments is a clear gap that the agent ecosystem is rapidly filling (see ERC-8183, x402 Foundation, Claw Earn, etc.). Happy to add more entries under this category as the ecosystem grows.

— Dario