### PR TITLE
Add TempGuru event staffing skills to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [kissmyabs32/tempguru-agent-skills](https://github.com/kissmyabs32/tempguru-agent-skills) - W-2 event staffing ordering and compliance for 300+ US and Canadian markets; live MCP pricing, availability, and state compliance lookups
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
-- [kissmyabs32/tempguru-agent-skills](https://github.com/kissmyabs32/tempguru-agent-skills) - W-2 event staffing ordering and compliance for 300+ US and Canadian markets; live MCP pricing, availability, and state compliance lookups
+- [tempguru-co/tempguru-agent-skills](https://github.com/tempguru-co/tempguru-agent-skills) - W-2 event staffing ordering and compliance for 300+ US and Canadian markets; live MCP lookups for pricing, availability, and state compliance, plus an opt-in request_quote submission
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adds [kissmyabs32/tempguru-agent-skills](https://github.com/kissmyabs32/tempguru-agent-skills) to the **Productivity and Collaboration** section of Community Skills.

Two skills:
- **`event-staffing-ordering`** — guides an agent from gathering event requirements through live MCP lookups (city coverage, role pricing, availability, state compliance) to a submitted staffing request for 300+ US and Canadian markets
- **`event-staffing-compliance`** — assesses worker-classification and compliance risk (W-2 vs 1099, joint-employer liability, COI, wage/hour) with live state-by-state lookups

## Quality signals

- Read-only, unauthenticated, script-free — plain markdown, no executable code
- MCP server live at `https://mcp.tempguru.co/mcp` (DNS-verified in Official MCP Registry as `co.tempguru/event-staffing`)
- Listed on skills.sh (19 runtimes), ClawHub, agentskill.sh, Smithery (90/100), ModelScope, agent-skills-hub, and more
- MIT license