### PR TITLE
Add skill: innovestrum/keelson

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [innovestrum/keelson](https://github.com/innovestrum/keelson) - Tracker-agnostic issue-driven workflow that gates agent spec-drift to a human
 </details>
 
 <details>


### PR DESCRIPTION
Adds **[innovestrum/keelson](https://github.com/innovestrum/keelson)** (MIT) under **Community Skills → Development and Testing**.

keelson is a real-world, tracker-agnostic operating model for AI coding agents, distilled from a production repo's flow. It ships two Agent Skills built on the SKILL.md standard:

- **adopt-keelson** — interviews you and writes a tracker-agnostic `AGENTS.md` plus a selectable lifecycle skill-pack.
- **tune-gates** — establishes or refines the quality gates, standalone.

It draws a hard line between **mechanical** moves the agent just makes (claim issue → branch → code+doc+test → open change → set status) and **consequential** ones it must hand back to a human (anything touching the original design, plan, or strategy) — so spec-drift surfaces the moment it happens. Provider-neutral: works with GitHub, GitLab, Jira, Linear, or any API/CLI/MCP.

Single-line addition to the existing collapsible category; link verified.