### PR TITLE
Add meta-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
+- [joohw/meta-skill](https://github.com/joohw/meta-skill) - Evaluate, differentiate, and design Agent Skills with a concise design brief
 </details>
 
 ---


### PR DESCRIPTION
Adds joohw/meta-skill to the Context Engineering community skills section.\n\nmeta-skill helps agents evaluate whether a new skill should exist, compare nearby alternatives, write a concise design brief, and define a distinctive skill identity before implementation.