### PR TITLE
Add LeadMagic/gtm-skills - 189 GTM playbooks for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
+- [LeadMagic/gtm-skills](https://github.com/LeadMagic/gtm-skills) - 189+ GTM playbooks for AI agents covering marketing, sales, customer success, and revenue operations across 26 categories. Compatible with Claude Code, Codex, Cursor, GitHub Copilot, and 12+ agent platforms. [Website](https://leadmagic.io/gtm-skills)
 </details>
 
 <details>


### PR DESCRIPTION
## Description

Adds [LeadMagic/gtm-skills](https://github.com/LeadMagic/gtm-skills) to the community Marketing skills section.

LeadMagic/gtm-skills is an open-source library of **189+ GTM (go-to-market) playbooks** for AI agents covering marketing, sales, customer success, and revenue operations across 26 categories spanning the full GTM stack.

### Details
- **Website:** https://leadmagic.io/gtm-skills
- **GitHub:** https://github.com/LeadMagic/gtm-skills
- **Compatible with:** Claude Code, Codex, Cursor, GitHub Copilot, and 12+ agent platforms
- **Categories:** 26 categories across the full GTM stack (marketing, sales, customer success, revenue operations)