### PR TITLE
Add skill directory: Skills by Openapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,19 @@ Official skills for ML workflows.
 - [better-auth/create-auth](https://agent-skill.co/better-auth/skills/create-auth) - Create authentication setup with Better Auth
 - [better-auth/twoFactor](https://agent-skill.co/better-auth/skills/twoFactor) - Two-factor authentication with Better Auth
 
+#### Skills by Openapi
+- [openapi/openapi-auth](https://github.com/openapi/openapi-skills/tree/main/skills/openapi-auth) - OAuth tokens, scopes and wallet for Openapi APIs
+- [openapi/openapi-company](https://github.com/openapi/openapi-skills/tree/main/skills/openapi-company) - Italian, EU and worldwide company data lookups
+- [openapi/openapi-documents](https://github.com/openapi/openapi-skills/tree/main/skills/openapi-documents) - Official Italian business documents and chamber-of-commerce reports
+- [openapi/openapi-risk](https://github.com/openapi/openapi-skills/tree/main/skills/openapi-risk) - Credit scores, due diligence and worldwide KYC
+- [openapi/openapi-trust](https://github.com/openapi/openapi-skills/tree/main/skills/openapi-trust) - Validate emails, phones, IPs and identities
+- [openapi/openapi-geo](https://github.com/openapi/openapi-skills/tree/main/skills/openapi-geo) - Italian geocoding, zip codes, cadastre and valuations
+- [openapi/openapi-messaging](https://github.com/openapi/openapi-skills/tree/main/skills/openapi-messaging) - Send SMS, certified e-mail and postal mail
+- [openapi/openapi-esignature](https://github.com/openapi/openapi-skills/tree/main/skills/openapi-esignature) - eIDAS electronic signatures and qualified timestamps
+- [openapi/openapi-invoicing](https://github.com/openapi/openapi-skills/tree/main/skills/openapi-invoicing) - Italian e-invoicing via SDI and bill payments
+- [openapi/openapi-automotive](https://github.com/openapi/openapi-skills/tree/main/skills/openapi-automotive) - European vehicle data by license plate
+- [openapi/openapi-utilities](https://github.com/openapi/openapi-skills/tree/main/skills/openapi-utilities) - Exchange rates, HTML-to-PDF, .it domains, managed RAG
+
 <details>
 <summary><strong>Marketing Skills by Corey Haines</strong></summary>
 


### PR DESCRIPTION
## What

Adds a **Skills by Openapi** block to *Business, Productivity & Marketing*, linking the official agent skills published by [Openapi](https://openapi.com) (European API marketplace — company data, KYC/risk, e-invoicing, e-signatures, geo data, messaging).

Repo: https://github.com/openapi/openapi-skills — 11 skills following the SKILL.md standard, installable with `npx skills add openapi/openapi-skills`.

## Notes for review

- Disclosure: I work on the Openapi team — these are our official skills, same spirit as the existing Stripe/Resend/Netlify blocks.
- Every skill is self-contained (auth flow, endpoints, workflows inlined) and documented; the repo also ships an A/B test harness ([test/](https://github.com/openapi/openapi-skills/tree/main/test)) measuring the with/without-skills difference on a real task.
- Links verified working; descriptions kept short per the existing style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)