### PR TITLE
feat: add ariadne-loop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [zhangzeyu99-web/ariadne-loop](https://github.com/zhangzeyu99-web/ariadne-loop/tree/main/skills/ariadne-loop) - Verifiable loop specs for coding agents
 </details>
 
 <details>


### PR DESCRIPTION
Adds Ariadne Loop to the Community Skills / Development and Testing section.

Ariadne Loop provides a SKILL.md package for writing verifiable Loop Engineering specs for Codex, Claude Code, OpenClaw, and other coding agents. It fits this section because it helps agent users turn coding loops into explicit verifier gates, rollback rules, and handoff packets.

Validation: git diff --check