### PR TITLE
Add CreatorSkills to How to Find Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ It is recommended to use the **[SkillsMP Marketplace](https://skillsmp.com)**, w
 
 You can also use **[skills.sh](https://skills.sh)** — Vercel's leaderboard — to intuitively view the most popular Skills repositories and individual Skill usage statistics.
 
+### CreatorSkills — Content Creator Marketplace
+
+**[CreatorSkills](https://creatorskills.co)** is a curated marketplace of 30+ downloadable AI skills purpose-built for content creators — covering YouTube scripting, sponsorship analysis, content repurposing, and audience growth. Skills use the open SKILL.md format and work with Claude, ChatGPT, and 20+ AI platforms.
+
 ### npx skills CLI Tool
 
 For specific skills, use the `npx skills` command-line tool to quickly discover, add, and manage skills. For detailed parameters, see [vercel-labs/skills](https://github.com/vercel-labs/skills).


### PR DESCRIPTION
## Summary

Adds [CreatorSkills](https://creatorskills.co) to the **How to Find Skills** section as a dedicated subsection alongside skills.sh and the npx skills CLI tool.

CreatorSkills is a curated marketplace of 30+ downloadable AI skills purpose-built for content creators — covering YouTube scripting, sponsorship analysis, content repurposing, and audience growth. Skills are distributed using the open **SKILL.md format** (the same standard this repo documents) and work with Claude Code, Claude.ai, ChatGPT, and 20+ other AI platforms.

This listing is relevant here because:
- It's a discovery channel specifically for content-creator skills in the SKILL.md format
- Complements skills.sh and the npx CLI as a curated marketplace option for non-technical users
- Links directly to the web platform (no GitHub account required to browse/download)