### PR TITLE
Add redbook director skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
+- [mythkiven/redbook-director-skill](https://github.com/mythkiven/redbook-director-skill) - Xiaohongshu/RedNote carousel visual planning skill
 </details>
 
 <details>


### PR DESCRIPTION
Adds redbook-director-skill to the Marketing community skills section.\n\nRepository: https://github.com/mythkiven/redbook-director-skill\n\nIt is an Agent Skill for Xiaohongshu/RedNote carousel visual planning, page structure, AI image prompts, captions, and review checklists.