### PR TITLE
Add Agent Skill Arena / 收录 Agent Skill Arena

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [qwqqwqis666/agent-skill-arena](https://github.com/qwqqwqis666/agent-skill-arena) - Compare Agent Skills through artifact-first tournaments
 </details>
 
 <details>


### PR DESCRIPTION
## 中文说明

本 PR 将 Agent Skill Arena 收录到 Community Skills > Development and Testing 分类。

Agent Skill Arena 是一个可安装的 Agent Skill 和纯 Python 评测工具，用于在相同任务、输入、工具和预算下比较多个同类 Skill。它以真实产出的成品为核心：成品质量占最终分的 70%，社区信号只占 3%；如果候选未达到明确质量线，结果可以是“不录取”。

### 验证

- 项目链接返回 HTTP 200
- `selecting-best-skill/SKILL.md` 通过官方快速验证器
- `website/` 中的 `npm run build` 构建成功
- 上游列表中不存在相同项目条目或重复 PR

项目：https://github.com/qwqqwqis666/agent-skill-arena

---

## English

Adds Agent Skill Arena to Community Skills > Development and Testing.

Agent Skill Arena is an installable Agent Skill and dependency-free toolkit for comparing competing skills through controlled, artifact-first tournaments. Produced artifact quality carries 70% of the final score, community signals carry 3%, and the tournament permits no selection when candidates miss explicit quality thresholds.

### Validation

- Repository link returns HTTP 200
- `selecting-best-skill/SKILL.md` passes the official quick validator
- `npm run build` succeeds in `website/`
- The upstream list had no existing Agent Skill Arena entry or PR