### PR TITLE
Add chubbyskills: Chinese content-ingestion skills + knowledge-base MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [chubbyguan/chubbyskills](https://github.com/chubbyguan/chubbyskills) - Ingest Chinese content (Douyin/Bilibili/Xiaohongshu/WeChat/X) into a knowledge base — image/video routing + MCP server
 </details>
 
 <details>


### PR DESCRIPTION
Adds **chubbyskills** — 14 skills for ingesting Chinese-platform content (Douyin, Bilibili, Xiaohongshu, WeChat, X/Twitter, podcasts) into a personal knowledge base, an area currently underrepresented in this list.

- Auto-routes image vs. video notes (images saved locally, videos transcribed)
- Subtitle-first transcription (no GPU needed when captions exist)
- Unified frontmatter + a knowledge-base MCP server so any MCP agent can query the vault
- Each skill is self-contained and independently installable; MIT licensed

Repo: https://github.com/chubbyguan/chubbyskills
