### PR TITLE
feat: add html2link publish skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 
 - [muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams) - Generate hand-drawn Excalidraw diagrams from prompt
 - [coderabbitai/skills](https://github.com/coderabbitai/skills) - Code review and PR autofix workflows
+- [joohw/html2link-skill](https://github.com/joohw/html2link-skill) - Publish agent artifacts to short browser share links
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop


### PR DESCRIPTION
## Summary

Adds `joohw/html2link-skill` to the Community Skills / Development and Testing index.

## Use case

The skill lets agents publish generated HTML reports, static site ZIPs, Markdown, PDF, spreadsheet, DOCX, and PPTX artifacts to short html2link.dev browser links.

## Links

- Canonical repo: https://github.com/joohw/html2link-skill
- Live published example: https://html2link.dev/x/yeiEwrKr

## Verification

- `npm ci` in `website/`
- `npm run build` in `website/`