### PR TITLE
Add SuperCLI - 4795+ agent skills for CLI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,8 @@ Install from [better-auth/skills](https://github.com/better-auth/skills).
 | Skill | Description |
 |-------|-------------|
 | [gstack](https://github.com/garrytan/gstack) | YC founder stack recommendations for infra, tooling, and deployment |
+#### Skills by SuperCLI
+- [javimosch/supercli](https://github.com/javimosch/supercli) - Universal CLI router with 4,795+ agent skills (`SKILL.md`). Agents discover CLI tools by intent via `sc skills search`, inspect schemas via `sc inspect`, and execute with deterministic JSON output. Each plugin ships with its own `skills/quickstart/SKILL.md` — instant agent onboarding for 7,000+ CLI tools.
 
 ---
 


### PR DESCRIPTION
SuperCLI is a universal CLI router that ships with 4,795+ agent skills (SKILL.md files), one for each bundled CLI tool plugin.

Why this belongs here:
- Each of the 7,000+ plugin directories includes a skills/quickstart/SKILL.md
- Agents discover tools by intent via sc skills search
- Agents inspect typed schemas before calling via sc inspect
- Every execution returns deterministic JSON, no parsing needed
- MCP-native runtime (consume and serve)
- Open source (MIT)

This is the largest single collection of agent skills (4,795+) for CLI tool discovery and execution.