### PR TITLE
Add Education and Teaching group (teaching-skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,12 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
 </details>
 
+<details>
+<summary><strong>Education and Teaching</strong></summary>
+
+- [YujxZJCN/teaching-skills](https://github.com/YujxZJCN/teaching-skills) - University teaching lifecycle for professors: course design, lessons, exams, grading (Codex: YujxZJCN/teaching-skills-codex)
+</details>
+
 ---
 
 ## Skill Quality Standards


### PR DESCRIPTION
Adds a new **Education and Teaching** group under Community Skills — a domain not yet represented — with [teaching-skills](https://github.com/YujxZJCN/teaching-skills).

A teaching-lifecycle suite for university professors: backward course design with constructive-alignment gates, lesson building, blueprint-first assessment, spec-driven submission auditing, student mentoring, learner analysis, and evaluation analysis. 15 skills, professor checkpoints throughout. Available for Claude Code and (as a sibling distribution) [OpenAI Codex CLI](https://github.com/YujxZJCN/teaching-skills-codex). English + 简体中文.

Plain-link format, terse description, new `<details>` group matching the existing topical grouping pattern (Vector Databases, Marketing, Context Engineering, …).