### PR TITLE
Add Xquik x-twitter-scraper to Agent Skill Index

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
+- [Xquik-dev/x-twitter-scraper](https://github.com/Xquik-dev/x-twitter-scraper/tree/master/skills/x-twitter-scraper) - X data, posting workflows, webhooks, and MCP
 </details>
 
 <details>


### PR DESCRIPTION
## What changed
Added the Xquik x-twitter-scraper skill to the Community Marketing section.

## Checks
- git diff --check
- Link check: Xquik skill directory returned HTTP 200

## Duplicate gate
Searched the target README, open and closed PRs, and open and closed issues for Xquik, x-twitter-scraper, x-developer, and xquik.com. No existing entry was found.