### PR TITLE
Add Mailtrap skills section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,14 @@ Official skills for ML workflows.
 - [resend/react-email](https://github.com/resend/resend-skills/tree/main/skills/react-email) - Build emails with React Email components
 - [resend/email-best-practices](https://github.com/resend/resend-skills/tree/main/skills/email-best-practices) - Email deliverability and design best practices
 
+#### Skills by Mailtrap
+
+- [mailtrap/sending-emails](https://github.com/mailtrap/mailtrap-skills/tree/main/skills/sending-emails) - Live sending via Email API and SMTP (transactional vs bulk)
+- [mailtrap/testing-with-sandbox](https://github.com/mailtrap/mailtrap-skills/tree/main/skills/testing-with-sandbox) - Email Sandbox, Testing API, safe capture in dev/staging
+- [mailtrap/setting-up-sending-domain](https://github.com/mailtrap/mailtrap-skills/tree/main/skills/setting-up-sending-domain) - Domain verification, DNS records, compliance
+- [mailtrap/managing-contacts](https://github.com/mailtrap/mailtrap-skills/tree/main/skills/managing-contacts) - Contacts API, lists, segments, CRM-style sync
+- [mailtrap/authorizing-api-requests](https://github.com/mailtrap/mailtrap-skills/tree/main/skills/authorizing-api-requests) - Token scope, auth headers, resolving account ID
+
 #### Skills by Sanity
 - [sanity-io/sanity-best-practices](https://agent-skill.co/sanity-io/skills/sanity-best-practices) - Best practices for Sanity Studio and content workflows
 - [sanity-io/content-modeling-best-practices](https://agent-skill.co/sanity-io/skills/content-modeling-best-practices) - Guidelines for designing scalable content models in Sanity


### PR DESCRIPTION
Adds 5 Mailtrap skills (sending-emails, testing-with-sandbox, setting-up-sending-domain, managing-contacts, authorizing-api-requests) under a new "Skills by Mailtrap" subsection in the Business, Productivity & Marketing section, following the same pattern as the existing Resend entry.