### PR TITLE
Add Consumer Dispute Assistant skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 <summary><strong>Productivity and Collaboration</strong></summary>
 
 - [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - Document processing: convert, OCR, and redact PII
+- [JerryNee/consumer-dispute-assistant](https://github.com/JerryNee/consumer-dispute-agent-skill/tree/main/skills/consumer-dispute-assistant) - Build refund and billing dispute case packs
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams


### PR DESCRIPTION
Adds `JerryNee/consumer-dispute-assistant` under Community Skills > Productivity and Collaboration.

The skill builds refund, subscription, and billing dispute case packs with templates, references, safety boundaries, demo output, and a reproducible JSON example.
