### PR TITLE
Add NotFair (SEO, GEO & paid-ads skills) to Business, Productivity & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ Official skills for ML workflows.
 - [better-auth/twoFactor](https://agent-skill.co/better-auth/skills/twoFactor) - Two-factor authentication with Better Auth
 
 #### Skills by NotFair
-Open-source SEO, GEO, and paid-ads skills for marketing work. They pull from live data through the Google Ads, Meta Ads, Google Search Console, and Google Analytics (GA4) MCP servers, so audits run against real numbers instead of guesses.
+Open-source SEO, GEO, and paid-ads skills for marketing work. They pull from live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP, so audits run against real numbers instead of guesses.
 - [nowork-studio/seo](https://github.com/nowork-studio/NotFair/tree/main/seo) - SEO and GEO: site analysis, keyword research, meta tags, schema markup, and content writing
 - [nowork-studio/google-ads](https://github.com/nowork-studio/NotFair/tree/main/google-ads) - Google Ads audits: wasted-spend detection, search-term cleanup, keyword and bid management
 - [nowork-studio/meta-ads](https://github.com/nowork-studio/NotFair/tree/main/meta-ads) - Meta (Facebook + Instagram) Ads: ROAS analysis, creative-fatigue and audience-overlap diagnosis

--- a/README.md
+++ b/README.md
@@ -345,6 +345,12 @@ Official skills for ML workflows.
 - [better-auth/create-auth](https://agent-skill.co/better-auth/skills/create-auth) - Create authentication setup with Better Auth
 - [better-auth/twoFactor](https://agent-skill.co/better-auth/skills/twoFactor) - Two-factor authentication with Better Auth
 
+#### Skills by NotFair
+Open-source SEO, GEO, and paid-ads skills for marketing work. They pull from live data through the Google Ads, Meta Ads, Google Search Console, and Google Analytics (GA4) MCP servers, so audits run against real numbers instead of guesses.
+- [nowork-studio/seo](https://github.com/nowork-studio/NotFair/tree/main/seo) - SEO and GEO: site analysis, keyword research, meta tags, schema markup, and content writing
+- [nowork-studio/google-ads](https://github.com/nowork-studio/NotFair/tree/main/google-ads) - Google Ads audits: wasted-spend detection, search-term cleanup, keyword and bid management
+- [nowork-studio/meta-ads](https://github.com/nowork-studio/NotFair/tree/main/meta-ads) - Meta (Facebook + Instagram) Ads: ROAS analysis, creative-fatigue and audience-overlap diagnosis
+
 <details>
 <summary><strong>Marketing Skills by Corey Haines</strong></summary>
 


### PR DESCRIPTION
Hi — thanks for maintaining this list. The provider-based layout made it easy to find where this fits.

I'd like to add **NotFair** to the Business, Productivity & Marketing section. It's an open-source (MIT) set of Claude Code skills for marketing — SEO, GEO, and Google/Meta ads. Around 2.9k people have starred it, so I'm hoping it's useful to others here too.

What it does:
- **SEO / GEO** — site analysis, keyword research, meta tags, schema, content
- **Google Ads** — audits that catch wasted spend and clean up keywords
- **Meta Ads** — ROAS, creative fatigue, and audience overlap

It connects to live data through the Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP, so audits run on real numbers rather than generic advice.

I kept the change to the README only and matched the format of the surrounding entries. Happy to reword, move, or trim it if you'd prefer.
