### PR TITLE
Add ax-extract-workflow skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
+- [Necmttn/ax-extract-workflow](https://github.com/Necmttn/ax/tree/main/skills/ax-extract-workflow) - Reconstruct shipped workflows from local ax sessions, commits, skills, and subagent traces
 </details>
 
 ---


### PR DESCRIPTION
## Summary

- Add `Necmttn/ax-extract-workflow` to Community Skills / Context Engineering
- Point readers to the ax skill for reconstructing shipped workflows from local sessions, commits, skills, and subagent traces

## Checks

- `git diff --check`
- `curl -L --head --fail https://github.com/Necmttn/ax/tree/main/skills/ax-extract-workflow`
- `npm --prefix website run build`
- subagent spec review
- subagent quality/copy review

Note: `npm --prefix website run lint` currently fails on existing website lint issues unrelated to this README-only change.

---

_Generated with [ax](https://github.com/Necmttn/ax)._
