### PR TITLE
Add ai-delivery-spec - product-side SDD framework with coding-agent handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [franklinxkk/ai-delivery-spec](https://github.com/franklinxkk/ai-delivery-spec) - Product-side spec-driven delivery framework: PRD, prototype, DDD/API/data contracts, acceptance gates, and coding-agent handoff (L0-L3 tiers, 4 domain modules)
 </details>
 
 <details>


### PR DESCRIPTION
## AI Delivery Spec - v4.9.2

**Product-side delivery standard** bridging the gap between product truth and AI coding agent handoff.

- **Repo**: https://github.com/franklinxkk/ai-delivery-spec | **Category**: Productivity & Collaboration

A meta-skill framework producing complete delivery packages coding agents consume:

1. **Human-First Full PRD** for PM/RD/QA/vendors
2. **AI-Coding Full PRD** + AC-YAML + API stubs + Event stubs + manifest.json + AGENTS.md
3. **Interaction Ledger**: 507KB prototype to 42KB JSON (agent context safety)

### v4.9.2 highlights
- 3 product work paths, Stage 4 TRK + BUG, FRR Completion Gate, Chinese-native ToB/ToG