### PR TITLE
Add skill: rxdage/The-teacher (Victory Methodology)

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [rxdage/The-teacher](https://github.com/rxdage/The-teacher) - Facts-first decision method that turns any messy problem into a plan; bilingual EN/中文
 </details>
 
 <details>


### PR DESCRIPTION
Adds **Victory Methodology** (`rxdage/The-teacher`) to Community Skills → Productivity and Collaboration.

It's a practical, de-ideologized decision-making method packaged as a Skill (`SKILL.md` + reference files). Given a messy real-world problem — work, money, family, a stuck life decision — it runs a calm, facts-first sequence instead of slogans: separate what you know from what you're assuming, find the one bottleneck that decides things now, build a small base you can hold, concentrate effort on a single front, and stage the rest. It has a setback-recovery mode that puts safety before strategy in a crisis, and a values mode that refuses to "compute" an answer to a question that was never a math problem.

Built for everyone, not just founders. Bilingual (English + 中文), CC BY-SA 4.0, eval-tested and converged over a 6-case set. Works on Claude.ai, Claude Code, and the API.

Repo: https://github.com/rxdage/The-teacher
