### PR TITLE
feat: add vibe-creating-skill under Creative and Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,12 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
 </details>
 
+<details>
+<summary><strong>Creative and Media</strong></summary>
+
+- [Alisa0808/vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill) - Rewrite rough ideas into model-ready text-to-video prompts (Seedance, Sora, Kling, Veo); bilingual EN/中文
+</details>
+
 ---
 
 ## Skill Quality Standards


### PR DESCRIPTION
## What is this?

[vibe-creating-skill](https://github.com/Alisa0808/vibe-creating-skill) is an open-source, bilingual (EN/中文) agent skill following the `SKILL.md` standard. It implements ByteDance's "Vibe Creating" prompt paradigm — introduced alongside the Seedance 2.0 video model — for AI video generation: instead of stuffing prompts with focal lengths, fps, and shot numbers, you describe the story/scene and let the model handle the cinematography. The skill is judgment-first: it first decides whether your input even suits this style before rewriting.

## Why it fits

It's a self-contained `SKILL.md` skill, runs across `SKILL.md`-compatible agents (Claude Code, Codex, OpenClaw, Hermes), and is open source (MIT). The Community Skills section had no Creative/Media category, so I added a new **Creative and Media** `<details>` block, matching the existing structure and the `[owner/repo](URL) - Description` entry format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)