### PR TITLE
Add Linked API skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,8 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [linkedin-skills](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin) - Fetch LinkedIn profiles, search people and companies, send messages, manage connections, create posts, react, comment, and run custom LinkedIn workflows from Claude Code, Codex, Cursor, and Windsurf.
+- [linkedin-growth](https://github.com/Linked-API/linkedin-skills/tree/main/linkedin-growth) - Import leads from LinkedIn or Sales Navigator searches, qualify them against an ideal-customer profile, schedule safe connection invites across accounts, track acceptances, and withdraw stale pending requests.
 </details>
 
 <details>


### PR DESCRIPTION
Adds both Linked API agent skills to the Community Skills > Productivity and Collaboration section.

- linkedin-skills: general-purpose LinkedIn automation through Linked API
- linkedin-growth: managed LinkedIn lead import, qualification, scheduling, and cleanup workflows

This replaces the stale/conflicting LinkedIn-only submission in #67, which was opened from a different fork.

Checks:
- README-only change
- website build not run because website/node_modules is not installed in this fork clone