### PR TITLE
Add RuleDoctor skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [syf2211/ruledoctor](https://github.com/syf2211/ruledoctor/tree/main/skills/ruledoctor) - Read project rules before coding
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adds RuleDoctor to the Development and Testing section.

RuleDoctor is a public Agent Skill for Claude Code, Codex, Cursor, and similar coding agents. It makes agents read project rule files such as `CLAUDE.md`, `AGENTS.md`, `.cursorrules`, `.cursor/rules`, and configured `required_reads` before editing code.

## Link

https://github.com/syf2211/ruledoctor/tree/main/skills/ruledoctor