### PR TITLE
Add skill: Dunteng/watch-video-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [Dunteng/watch-video-skill](https://github.com/Dunteng/watch-video-skill) - Evidence-first video understanding for Codex
 </details>
 
 <details>


### PR DESCRIPTION
This PR adds watchvideo to the Productivity and Collaboration community skills section.

watchvideo is a Codex skill + local CLI for evidence-first video understanding. It prepares subtitles or local transcription, keyframes, optional OCR, and grounded reports before the agent summarizes.

Repository: https://github.com/Dunteng/watch-video-skill

Validation:
- `npm ci`
- `npm run build`

Note: `npm ci` completed successfully and reported existing dependency audit findings in the website dependency tree.