### PR TITLE
docs: add Your Prompt Engineer

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
+- [polychrome7/your-prompt-engineer](https://github.com/polychrome7/your-prompt-engineer) - Prompt handoff layer that turns rough requests into dispatch-ready agent prompts with target validation, routing, confirmation, and safety gates
 </details>
 
 ---

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
-- [polychrome7/your-prompt-engineer](https://github.com/polychrome7/your-prompt-engineer) - Prompt handoff layer for Codex and Claude Code that turns rough requests into dispatch-ready agent prompts with target validation, routing, confirmation, and safety gates
+- [polychrome7/your-prompt-engineer](https://github.com/polychrome7/your-prompt-engineer) - Prompt handoff layer for Codex, Claude Code, and compatible agent hosts, with target validation, routing, confirmation, and safety gates
 </details>
 
 ---

--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
-- [polychrome7/your-prompt-engineer](https://github.com/polychrome7/your-prompt-engineer) - Prompt handoff layer that turns rough requests into dispatch-ready agent prompts with target validation, routing, confirmation, and safety gates
+- [polychrome7/your-prompt-engineer](https://github.com/polychrome7/your-prompt-engineer) - Prompt handoff layer for Codex and Claude Code that turns rough requests into dispatch-ready agent prompts with target validation, routing, confirmation, and safety gates
 </details>
 
 ---


### PR DESCRIPTION
## What changed

Adds Your Prompt Engineer to the Community Skills / Context Engineering section.

## Why

Your Prompt Engineer is a prompt handoff layer for Codex and Claude Code agents. It turns rough requests into dispatch-ready agent prompts with target validation, explorer/worker routing, confirmation before dispatch, and safety gates.

## Validation

- Ran `npm ci` in `website/`
- Ran `npm run build` in `website/`
