### PR TITLE
docs: add github-issue-fix skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 
 - [muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams) - Generate hand-drawn Excalidraw diagrams from prompt
 - [coderabbitai/skills](https://github.com/coderabbitai/skills) - Code review and PR autofix workflows
+- [OSS-AIE/github-issue-fix](https://github.com/OSS-AIE/github-issue-fix) - GitHub issue and PR repair workflow for Codex: triage upstream issues, fix CI, address review comments, resolve conflicts, and prepare reviewer-friendly PRs.
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop


### PR DESCRIPTION
## Summary\n\nAdd OSS-AIE/github-issue-fix to the Community Skills / Development and Testing section.\n\nThe skill gives Codex a repeatable GitHub issue and PR repair workflow for triage, CI fixes, review comments, conflicts, and PR handoff notes.\n\n## Validation\n\n- README-only change\n- Verified the target repository contains a top-level SKILL.md