### PR TITLE
Add Backblaze B2 cloud-storage skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,12 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 </details>
 
 <details>
+<summary><strong>Cloud Storage</strong></summary>
+
+- [backblaze-labs/claude-skill-b2-cloud-storage](https://github.com/backblaze-labs/claude-skill-b2-cloud-storage) - Manage Backblaze B2 storage: list, audit, cleanup, security, lifecycle
+</details>
+
+<details>
 <summary><strong>Marketing</strong></summary>
 
 - [BrianRWagner/ai-marketing-skills](https://github.com/BrianRWagner/ai-marketing-skills) - 17 marketing frameworks for outreach and audits


### PR DESCRIPTION
Adds the Backblaze B2 Cloud Storage skill under Community Skills in a new Cloud Storage group (matching the single-entry Vector Databases pattern).

- Repo: https://github.com/backblaze-labs/claude-skill-b2-cloud-storage (MIT)
- Manages Backblaze B2 from the terminal: list, audit, cleanup, security review, lifecycle.
- Built on the open Agent Skills SKILL.md spec; SKILL.md under 500 lines, tested, documented.