### PR TITLE
feat: add simple-webpage skill — vanilla HTML/CSS/JS reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [yuzu-octopus/simple-webpage](https://github.com/yuzu-octopus/simple-webpage) - Vanilla webpage builder: 1,796-line SKILL.md with 42 cookbook patterns, design tokens, and 250+ CSS techniques. Build webpages with vanilla HTML/CSS/JS — no frameworks, no build steps.
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adds [simple-webpage](https://github.com/yuzu-octopus/simple-webpage) to the Development and Testing section.

**What it is:** A comprehensive vanilla webpage builder skill for AI agents. 1,796-line SKILL.md with 42 standalone cookbook patterns, 4-layer design token system, and MCP integration (Context7, Exa, Playwright).

**Why it fits:** Teaches AI agents to build webpages with vanilla HTML/CSS/JS — no frameworks, no build steps. Compatible with Claude Code, Codex, Copilot, and other agent platforms.

**Key features:**
- 42 self-contained HTML cookbook patterns (layouts, navigation, forms, cards, effects, interactivity, typography)
- Design token system (base, semantic, components, typography)
- Framework allowlist with 18+ curated CSS libraries
- MCP integration for documentation research
- 250+ CSS techniques extracted from 75 video transcripts

**Size note:** SKILL.md is 1,796 lines (exceeds the 500-line "optimal" guideline) — justified by comprehensive cookbook cross-references and 12 reference sections covering the full vanilla CSS/JS landscape.