### PR TITLE
Add zj021033 agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
+- [zj021033/mask](https://github.com/zj021033/mask) - Character-voice rewriting for AI copy
 </details>
 
 <details>
@@ -549,6 +550,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [zj021033/senior-mode](https://github.com/zj021033/senior-mode) - Root-cause discipline for coding agents
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adds two community Agent Skills to the index:

- zj021033/mask under Marketing
- zj021033/senior-mode under Development and Testing

Both repositories include SKILL.md, README documentation, release tags, and install instructions.

## Validation

- Ran git diff --check
- Website build not run because this is a README-only link update