### PR TITLE
Add Agent Workflow Pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 
 - [muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams) - Generate hand-drawn Excalidraw diagrams from prompt
 - [coderabbitai/skills](https://github.com/coderabbitai/skills) - Code review and PR autofix workflows
+- [MemoAsh/agent-workflow-pack](https://github.com/MemoAsh/agent-workflow-pack) - Portable PR-review workflow skill with `AGENTS.md`, `SKILL.md`, templates, verification checks, and completion receipts
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop


### PR DESCRIPTION
Adds MemoAsh/agent-workflow-pack to the Community Skills / Development and Testing section. The repo provides a portable PR-review workflow skill with AGENTS.md, SKILL.md, templates, verification checks, and completion receipts.\n\nVerification:\n- Confirmed https://github.com/MemoAsh/agent-workflow-pack returns HTTP 200.\n- Ran \git diff --check\ locally; only Windows line-ending warnings were reported.