### PR TITLE
feat: add gui-tool skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
-- [ZachRouan/gui-tool](https://github.com/ZachRouan/agent-desktop-interface/tree/main/skills/gui-tool) - Zero-dependency Rust CLI for cross-platform GUI and desktop automation built for AI agents.
+- [ZachRouan/gridhand](https://github.com/ZachRouan/gridhand/tree/main/skills/gridhand) - Zero-dependency Rust CLI for cross-platform GUI and desktop automation built for AI agents.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [ZachRouan/gui-tool](https://github.com/ZachRouan/agent-desktop-interface/tree/main/skills/gui-tool) - Zero-dependency Rust CLI for cross-platform GUI and desktop automation built for AI agents.
 </details>
 
 <details>


### PR DESCRIPTION
Adds **gui-tool** under Community Skills → Development and Testing.

It's a real, published tool (on crates.io, MIT) — a zero-dependency Rust CLI for cross-platform GUI/desktop automation that AI agents drive by naming a labeled grid cell over a screenshot instead of reading the accessibility tree. The Agent-Skills-standard `SKILL.md` lives at `skills/gui-tool/SKILL.md` (well under the 500-line limit) and the CLI works on Linux/macOS/Windows with strict JSON in/out.

Repo: https://github.com/ZachRouan/agent-desktop-interface
Skill: https://github.com/ZachRouan/agent-desktop-interface/tree/main/skills/gui-tool