### PR TITLE
Add Obsidian CLI Plugins skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [DXShelley/obsidian-cli-plugins-skill](https://github.com/DXShelley/obsidian-cli-plugins-skill) - Obsidian vault records, tasks, project notes, attachments, and Git sync
 </details>
 
 <details>


### PR DESCRIPTION
## Summary\n- Adds Obsidian CLI Plugins to Productivity and Collaboration community skills.\n- Skill repo: https://github.com/DXShelley/obsidian-cli-plugins-skill\n\n## Notes\n- The skill follows the SKILL.md format and includes bundled scripts, references, tests, and documentation.\n- ClawHub publication: obsidian-cli-plugins@1.0.0.\n\n## AI assistance disclosure\nThis PR was prepared with Codex assistance; the submitted change is a single curated README entry.