### PR TITLE
Add routerbase agent skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [zenlee123/routerbase-agent-skills](https://github.com/zenlee123/routerbase-agent-skills) - Agent skills for using [routerbase](https://routerbase.com/) as an OpenAI-compatible gateway, model routing layer, and media generation interface
 </details>
 
 <details>


### PR DESCRIPTION
Adds the public routerbase-agent-skills collection to the Community Skills / Development and Testing section.\n\nThe repository provides three SKILL.md packages for using routerbase as an OpenAI-compatible gateway, model routing layer, and media generation interface.\n\nSource: https://github.com/zenlee123/routerbase-agent-skills\nWebsite: https://routerbase.com/\n\nValidation:\n- Checked the repository for existing routerbase entries\n- Added one concise README entry using the existing format\n- Checked for accidental private email or real API key leakage\n- Ran git diff --check