### PR TITLE
docs: add TakoAPI directory badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Agent Skill Index
 
+[![Listed on TakoAPI](https://takoapi.com/api/badge/heilcheng-awesome-agent-skills)](https://takoapi.com/agents/heilcheng-awesome-agent-skills)
+
 [English](README.md) | [繁體中文](README.zh-TW.md) | [简体中文](README.zh-CN.md) | [日本語](README.ja.md) | [한국어](README.ko.md) | [Español](README.es.md)
 
 [![Agent Skill Index Banner](assets/banner.png)](https://agent-skill.co)


### PR DESCRIPTION
Hi! 👋 **awesome-agent-skills** is listed in the [TakoAPI](https://takoapi.com) open agent directory — a free, open catalog that helps people discover AI-agent projects ("one API to discover all agents").

Your listing: https://takoapi.com/agents/heilcheng-awesome-agent-skills

This PR adds a small badge near the top of the README that links back to that listing, so visitors can find the directory entry. It's entirely optional — if you'd prefer not to include it, just close this PR (no hard feelings, and apologies for the noise).

No tracking and no obligations. Thanks for building awesome-agent-skills! 🙏