### PR TITLE
Add autonomous-decision-audit skill (Finance and Trading)

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,12 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
 </details>
 
+<details>
+<summary><strong>Finance and Trading</strong></summary>
+
+- [Autonomous-Asset-Management-Agents/autonomous_](https://github.com/Autonomous-Asset-Management-Agents/autonomous_/tree/main/packages/autonomous-audit) - Tamper-evident SHA-256 hash-chain audit log + HTML report for AI trading-agent decisions; read-only, offline, Apache-2.0, Python stdlib only
+</details>
+
 ---
 
 ## Skill Quality Standards


### PR DESCRIPTION
## Summary
Adds a **Finance and Trading** category to Community Skills with **autonomous-decision-audit** — a tamper-evident SHA-256 hash-chain audit log + HTML report for AI trading-agent decisions (read-only, offline, Apache-2.0, Python standard library only). This fills a gap: there was no finance/trading (or audit/integrity) category yet.

Meets the repo's Skill Quality Standards: focused single-purpose scope, working CLI examples (`uvx autonomous-audit demo`), a documented cross-language hash contract, and **explicitly documented trade-offs** — the skill is honest that it is tamper-*evident* (detects in-place edits/reorders/mid-deletions) but not tamper-*proof* durable storage, and not a regulatory control.
