### PR TITLE
Add AgentBodega skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [agentbodegastore/agentbodega](https://github.com/agentbodegastore/agentbodega/tree/main/agent-skills/agentbodega) - Discover, price, and call x402-payable AgentBodega utility APIs
 </details>
 
 <details>


### PR DESCRIPTION
Adds AgentBodega to the Community Skills / Development and Testing section.

AgentBodega now hosts a standalone SKILL.md at agent-skills/agentbodega/SKILL.md. The skill teaches agents how to discover, price, and call AgentBodega x402-payable HTTP utilities without guessing schemas.

Checks performed:
- `git diff --check`
- `node /Users/isiah/repos/agentbodega/scripts/public-identity-gate.mjs --range HEAD`
