### PR TITLE
Add Maoxuan Product Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 <details>
 <summary><strong>Productivity and Collaboration</strong></summary>
 
+- [atdy/maoxuan-product-agent](https://github.com/atdy/maoxuan-product-agent) - Chinese product decision agent distilled from *On Contradiction* and *On Practice*; identifies the core constraint and returns prioritized actions without exposing theory
 - [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - Document processing: convert, OCR, and redact PII
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence


### PR DESCRIPTION
## What changed

- Add `atdy/maoxuan-product-agent` to Community Skills > Productivity and Collaboration.
- Describe its source methodology and product-decision outcome in one focused directory entry.

## Why it fits

- Provides a valid, documented `SKILL.md` with supporting references and a local quality gate.
- Handles real product, growth, operations, data, roadmap, prioritization, and cross-team scenarios in Chinese.
- Distills the reasoning structure of *On Contradiction* and *On Practice* while keeping normal answers in modern product language.
- Supports Claude Code, Codex, Cursor, and other Agent Skills-compatible hosts.
- Includes 36 documented regression scenarios and 4 fresh Claude Code forward tests.

## Verification

- `npm ci` in `website/`
- `npm run build` in `website/`
- Source repository and GitHub Pages links return HTTP 200
