### PR TITLE
Add linked-notes (Obsidian project notes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - Document processing: convert, OCR, and redact PII
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
+- [tpklo/claude-note](https://github.com/tpklo/claude-note) - Obsidian project notes from agent sessions, linked into the vault's knowledge graph
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
 </details>
 


### PR DESCRIPTION
Adds [linked-notes](https://github.com/tpklo/claude-note) to Community Skills.

Creates Obsidian project notes from agent sessions, wired into the vault's knowledge graph (wikilinks, backlinks, hub-note registration). One-time setup auto-detects vaults from Obsidian's registry; optional Notion sync. Cross-platform SKILL.md — works in Claude Code, Codex CLI, Gemini CLI, and Cursor. MIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)