### PR TITLE
Add skill: lbk-open/super-spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [lbk-open/super-spec](https://github.com/lbk-open/super-spec) - Requirement or production alert to a reviewed PR, with multi-agent TDD coding and a parallel review panel
 </details>
 
 <details>


### PR DESCRIPTION
Adds **SuperSpec** — https://github.com/lbk-open/super-spec — to *Community Skills → Development and Testing*.

20 Agent Skills from one `SKILL.md` source, loaded unchanged by Claude Code, Codex, Pi, and OpenCode.

It combines the engineering discipline of [superpowers](https://github.com/obra/superpowers) with the living spec lifecycle of [OpenSpec](https://github.com/Fission-AI/OpenSpec), and adds what neither has: end-to-end workflows that carry a requirement — or a production alert — all the way to a reviewed pull request, plus multi-repo orchestration.

- Implementation is dispatched to parallel test-driven subagents; a review panel with distinct lenses then returns a severity-graded verdict and drives a bounded fix loop until the code passes.
- Root-cause analysis is evidence-based: competing hypotheses are falsified against logs, traces, metrics, code and git history before a fix is written.
- Capability specs follow the OpenSpec directory convention, so an OpenSpec-initialized repo works as-is.
- Nothing is written into your project; guardrails are read in place at runtime.

Apache-2.0, v0.1.1, actively maintained. Entry kept to the section's one-line format.