### PR TITLE
Add UIZZE UI research skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [aislon/uizze-ui-research](https://github.com/aislon/uizze-mcp/tree/main/skills/uizze-ui-research) - Research real UI references, define design contracts, and validate implementations against them
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adds the official `uizze-ui-research` skill to Development and Testing, alongside the directory's existing anti-slop frontend skill.

## Why

UIZZE gives agents a reusable workflow for researching real web and iOS UI references, defining project-specific design contracts, and validating implementations without copying another product's branded interface.

## Validation

- Verified the official `SKILL.md` source URL.
- Ran `git diff --check`.
- Ran `npm run build --prefix website` successfully.
