### PR TITLE
Add Vladimir-Human/humanizer-ru skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
+- [Vladimir-Human/humanizer-ru](https://github.com/Vladimir-Human/humanizer-ru) - Russian AI-writing cleanup with 38 style patterns and 35 regex markers.
 </details>
 
 <details>


### PR DESCRIPTION
## Summary
Adds `Vladimir-Human/humanizer-ru` — a Russian AI-writing cleanup skill with 38 style patterns and 35 deterministic regex markers.

## Why it fits
- Russian-specific AI-writing cleanup: 38 style patterns and 35 deterministic regex markers
- MIT-licensed, portable across Claude Code, Codex, Cursor, Gemini CLI, and OpenCode
- 61 GitHub stars, 266+ installs on skills.sh
- No network service required; offline self-scan in CI
- Fits the Marketing section alongside `SHADOWPR0/beautiful_prose` (English prose quality) and other writing-related skills

I checked the list and existing pull requests for the repository URL before submitting.