### PR TITLE
Add claude-video-plus (new Video & Media category)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ That's it. No installation. No configuration. No coding required.
   - [Productivity and Collaboration](#productivity-and-collaboration)
   - [Development and Testing](#development-and-testing)
   - [Context Engineering](#context-engineering)
+  - [Video & Media](#video--media)
 - [Skill Quality Standards](#skill-quality-standards)
 - [Using Skills](#using-skills)
 - [Creating Skills](#creating-skills)
@@ -557,6 +558,12 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
+</details>
+
+<details>
+<summary><strong>Video & Media</strong></summary>
+
+- [abe238/claude-video-plus](https://github.com/abe238/claude-video-plus) - Ask a video a question; retrieves only the chapters, numbers, and on-screen moments that answer it instead of sampling the whole timeline
 </details>
 
 ---


### PR DESCRIPTION
## What

Adds [`abe238/claude-video-plus`](https://github.com/abe238/claude-video-plus) to Community Skills. There was no video/media category, so this creates a **Video & Media** section (with a matching Table of Contents entry).

## The skill

`/watch` gives an agent a video as input. Ask it a question and it retrieves only the evidence that answers it — whole topical chapters, on-screen numeric facts (pricing/specs), and "as you can see" moments — instead of sampling the entire timeline. Installs via `npx skills add abe238/claude-video-plus -g` or the Claude Code marketplace.

## Why it meets the quality standards

- **Self-contained `SKILL.md`** with a caption-first, fail-open design; reverts to the original full-timeline pipeline on any problem (no captions, local file, short video, any error).
- **Documented trade-offs** — the README states every limitation directly (lexical retrieval, summaries keep the full transcript, full download still required for frame modes).
- **Tested & measured** — 338 deterministic tests, and a sealed, receipt-gated benchmark with published raw data (including losses).
- It's an attributed MIT fork of [`bradautomates/claude-video`](https://github.com/bradautomates/claude-video), upstream authorship preserved.

README-only change (no `website/` code touched); the entry links to GitHub per the Community Skills convention.