### PR TITLE
Add idea-hunt skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
+- [ANVEAI/idea-hunt-skill](https://github.com/ANVEAI/idea-hunt-skill) - Evidence-first AI business idea discovery and validation with kill-gates and a proof-of-wallet test
 </details>
 
 <details>


### PR DESCRIPTION
### Adding: idea-hunt

**Repo:** https://github.com/ANVEAI/idea-hunt-skill · MIT · single self-contained `SKILL.md` — no API key or paid subscription required to function.

**What it does:** Evidence-first AI business idea discovery & validation. It inverts the usual "invent an idea" prompt: it hunts for an existing, already-paid-for workflow AI can now do as *completed work*, then runs a 7-stage pipeline — pain mining → kill-gates → the Mom Test → a proof-of-wallet test — so weak ideas get rejected on paper before any build.

- [x] Actively maintained, documented (README + FAQ)
- [x] No commercial-API / paid-subscription dependency
- [x] Real value for Claude / Claude Code users
- [x] Concise, single-sentence description