### PR TITLE
Add Ditto to Context Engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
+- [ohad6k/ditto](https://github.com/ohad6k/ditto) - Mine Claude Code and Codex session logs into local, evidence-backed agent profiles
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
 </details>
 


### PR DESCRIPTION
## What

Adds [Ditto](https://github.com/ohad6k/ditto) to the Context Engineering community skills section. Ditto mines local Claude Code and Codex session history into evidence-backed agent profiles.

## Verification

- `git diff --check`
- `npm ci` in `website/`
- `npm run build` in `website/`