### PR TITLE
Add readme-skill to Community Skills (Development and Testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [evol1228/readme-skill](https://github.com/evol1228/readme-skill) - Write professional, hand-crafted README.md files grounded in the actual repo
 </details>
 
 <details>


### PR DESCRIPTION
Adds [evol1228/readme-skill](https://github.com/evol1228/readme-skill) — writes professional, hand-crafted README.md files grounded in the actual repo (real commands, ports, env vars), with anti-slop style rules and per-project-type structure. `npx skills add evol1228/readme-skill`, MIT licensed, passing security audits on [skills.sh](https://www.skills.sh/evol1228/readme-skill).