### PR TITLE
feat: add website-seo-audit to Marketing community skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
+- [zxhydfzr/website-seo-audit](https://github.com/zxhydfzr/website-seo-audit) - Zero-dependency SEO auditor with structured-data (JSON-LD) checks, runs as CLI or agent skill
 </details>
 
 <details>


### PR DESCRIPTION
Adds **website-seo-audit** to the Community Skills → Marketing list.

- Repo: https://github.com/zxhydfzr/website-seo-audit
- A zero-dependency (Python stdlib only) SEO auditor that crawls a site and grades it across on-page, technical, and JSON-LD / Schema.org structured-data checks. No API keys. Ships a `SKILL.md` (under 500 lines) so any agent supporting the Agent Skills standard — Claude Code, Codex, opencode — can run it and explain the results conversationally.
- Sits well alongside the existing `AgriciDaniel/claude-seo` entry; its distinguishing focus is structured-data (JSON-LD) validation and zero-install CLI-or-skill packaging.

Appended to the end of the Marketing `<details>` block, matching the `owner/repo` entry format. Edited README only.