### PR TITLE
feat: add sergebulaev social-media skills to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,8 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 
 ---
 
+- [sergebulaev/linkedin-skills](https://github.com/sergebulaev/linkedin-skills) - Social media marketing skills for 7 platforms: corpus-validated hooks, humanizer, audience insights
+
 ## Skill Quality Standards
 
 When evaluating or contributing skills, look for:


### PR DESCRIPTION
Adds [sergebulaev/linkedin-skills](https://github.com/sergebulaev/linkedin-skills) to **Community Skills**, next to the other marketing/SEO community entries.

Flagship of a 7-platform social-media marketing family (LinkedIn, X, Instagram, YouTube, TikTok, Threads, Facebook), all following the `SKILL.md` standard for Claude Code and Codex. Hook formulas are validated against real high-performing-post corpora; each bundle ships a humanizer and an audience-insights read layer. 378 stars, MIT. One short entry, existing list format.