### PR TITLE
Add skill: sarveshsea/audit-frontend-design

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [sarveshsea/audit-frontend-design](https://github.com/sarveshsea/memi/tree/main/skills/audit-frontend-design) - Audit frontend design debt before editing code
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adds Memi's focused `audit-frontend-design` Agent Skill to Development and Testing. The skill audits frontend design debt before code edits and works with Codex, Claude Code, Cursor, and other Agent Skills clients.

## Verification

- direct `SKILL.md` repository link returns HTTP 200
- `npm run build` passes in `website/`
- public install proof: `npx -y skills add sarveshsea/memi --skill audit-frontend-design --yes`

Skill source: https://github.com/sarveshsea/memi/tree/main/skills/audit-frontend-design