### PR TITLE
Add gooseworks-ai/goose-skills to Community Skills > Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
+- [gooseworks-ai/goose-skills](https://github.com/gooseworks-ai/goose-skills) - 125 growth/GTM skills for ads, lead gen, outreach, and SEO
 </details>
 
 <details>


### PR DESCRIPTION
Adds [goose-skills](https://github.com/gooseworks-ai/goose-skills) to the **Community Skills → Marketing** section.

Open-source (MIT) library of 125 growth/GTM skills — ads, content, lead generation, outreach, competitive intelligence, monitoring, research, and SEO — for Claude Code, Codex, and Cursor. 1,000+ stars, installable via CLI, per-skill SKILL.md with metadata contract.

— Himanshu Bamoria, co-founder @ [GooseWorks](https://gooseworks.ai)

🤖 Generated with [Claude Code](https://claude.com/claude-code)