### PR TITLE
Add go-agent-skills — curated Go skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [eduardo-sl/go-agent-skills](https://github.com/eduardo-sl/go-agent-skills) - 28 curated Go skills for code review, concurrency, testing, and architecture
 </details>
 
 <details>


### PR DESCRIPTION
## What

Adds [go-agent-skills](https://github.com/eduardo-sl/go-agent-skills) — a collection of 28 curated agent skills for Go projects — to Community Skills → Development and Testing.

## Why it fits this list

- Covers code review, concurrency review, error handling, testing (table-driven), gRPC, observability, and architecture for Go
- Built on established references: Uber Go Style Guide, Effective Go, Go Code Review Comments
- Works across Claude Code, Cursor, Codex, GitHub Copilot, Windsurf, OpenCode (37+ agents)
- One-command install: `npx skills add eduardo-sl/go-agent-skills`
- MIT licensed, CI validation for skill format, contribution guidelines in place

## Skill Quality Standards checklist

- **Clear instructions**: each skill's SKILL.md has unambiguous, actionable steps
- **Appropriate scope**: skills are split by focused task (code review, concurrency, testing, gRPC, architecture, etc.), not one monolithic skill
- **Working examples**: skills include real Go usage examples, not just theory
- **Documented trade-offs**: limitations and edge cases noted per skill
- **Size limit**: all SKILL.md files are under 500 lines
- **Tested**: verified against Claude Code, Cursor, Codex, GitHub Copilot, Windsurf, and OpenCode; CI validates skill format

I followed the entry format of the surrounding entries in this section. Happy to adjust anything.