### PR TITLE
feat: add UIZZE UI design skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [samuelbushi/uizze](https://github.com/samuelbushi/uizze/tree/main/skills/anti-ui-slop) - Ground UI decisions in 800,000+ real screens and enforce a finish gate
 </details>
 
 <details>


### PR DESCRIPTION
Adds the public UIZZE `anti-ui-slop` skill under Development and Testing.\n\nIt is an instruction-only, free-to-use workflow for Codex, Claude Code, Cursor, Copilot, Windsurf, and compatible agents: it grounds UI decisions in real interface evidence and adds a pre-ship finish gate.\n\nValidation: confirmed the GitHub skill link returns HTTP 200 and the repository contains a standard `SKILL.md` with name and description frontmatter.