### PR TITLE
Add IntentFence x402 payment guard skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,12 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
 </details>
 
+<details>
+<summary><strong>Security and Safety</strong></summary>
+
+- [razel369/guard-x402-payments](https://github.com/razel369/intentfence/tree/main/skills/guard-x402-payments) - Validate x402 quotes, ceilings, and payee allowlists before agents sign
+</details>
+
 ---
 
 ## Skill Quality Standards


### PR DESCRIPTION
## What changed

- Add a `Security and Safety` community category.
- List `razel369/guard-x402-payments`, a portable Agent Skill that checks exact x402 quotes, price ceilings, and payee allowlists before an agent signs.

## Why

Autonomous payment agents need a reviewable pre-signing boundary. The linked skill keeps wallet credentials local, requires explicit authorization for its assessment fee, and provides a capped Coinbase Agentic Wallet path.

## Validation

- The linked GitHub skill URL returns HTTP 200.
- The skill passes the Agent Skills structural validator and is discovered by the Vercel Skills CLI from `razel369/intentfence`.
- IntentFence validation passes: production build, 27 application tests, 3 MCP tests, lint, TypeScript, and SDK checks.
- I attempted the index website build, but local `npm ci` stopped with `ENOSPC` before the build could start. This PR changes only `README.md`.