### PR TITLE
Add Codex skin pack installer skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [ChannelerH/codex-skin-pack-installer](https://github.com/ChannelerH/codex-skin-packs/tree/main/skills/codex-skin-pack-installer) - Install and restore verified Codex desktop skin packs with backup-first agent prompts
 </details>
 
 <details>


### PR DESCRIPTION
## Summary
- Add Codex Skin Pack Installer to the Community Skills / Development and Testing section.
- Links directly to a SKILL.md-based installer for verified Codex desktop skin packs.
- The skill focuses on backup-first install, apply, remix, and restore prompts.

## Verification
- `npm ci`
- `npm run build`
- `npx skills add ChannelerH/codex-skin-packs --list` finds `codex-skin-pack-installer`
- `npx skills add ChannelerH/codex-skin-packs --skill codex-skin-pack-installer --global --agent codex --yes` installs successfully in an isolated HOME
