### PR TITLE
feat: add santowilem/clone-ui to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [santowilem/clone-ui](https://github.com/santowilem/skills/tree/main/skills/clone-ui) - Pixel-faithful UI cloning from URL, screenshot, or Figma with anti-hallucination verification
 </details>
 
 <details>


### PR DESCRIPTION
Adds `clone-ui` to **Community Skills → Development and Testing**.

**What it is:** a SKILL.md-standard skill for pixel-faithful UI cloning from a live URL, a screenshot, or a Figma frame. It runs a 7-phase anti-hallucination flow — extract the real computed styles/typography/assets from the source, rebuild section-by-section, then adversarial sub-agent verification with computed-style parity checks — and outputs production-ready code (React, Vue, Next.js, Astro, Svelte, or plain HTML). Works across Claude Code, Cursor, Codex CLI, ChatGPT, and Copilot.

- Repo: https://github.com/santowilem/skills
- Skill: https://github.com/santowilem/skills/tree/main/skills/clone-ui
- Install: `npx skills add santowilem/skills --skill clone-ui`

README-only change (single entry line); no `website/` or build impact.