### PR TITLE
Add nanyumeng/superpowers-lite skills overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [nanyumeng/superpowers-lite](https://github.com/nanyumeng/superpowers-lite) - Unofficial, reversible skills overlay for obra/superpowers with risk-proportional coding workflows
 </details>
 
 <details>


### PR DESCRIPTION
## What changed

- Added `nanyumeng/superpowers-lite` to **Community Skills → Development and Testing**.
- Kept the entry concise and identified it as an unofficial overlay rather than a replacement for upstream Superpowers.

## Why it fits

Superpowers Lite preserves the established skill names, TDD, and fresh-verification guardrails from `obra/superpowers` while making planning and orchestration proportional to task risk. It is based on upstream v6.1.1 and ships a complete, documented skills tree.

I maintain the listed project. It is an unofficial derivative and is not endorsed by Superpowers, OpenAI, or Anthropic. The repository documents [reversible installation and rollback](https://nanyumeng.github.io/superpowers-lite/install/) and separates [source measurements from maintainer field observations](https://nanyumeng.github.io/superpowers-lite/evidence/).

## Checks

- `npm run build` in `website/` — passed
- Repository link and target section — verified
- One list item only; no generated website or translation files changed
