### PR TITLE
Add claude-code-eyes to Community Skills (Development and Testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [fcavalcantirj/claude-code-eyes](https://github.com/fcavalcantirj/claude-code-eyes) - Camera vision for Claude Code — see hardware, screens and wiring to verify physical output
 </details>
 
 <details>


### PR DESCRIPTION
Adds [claude-code-eyes](https://github.com/fcavalcantirj/claude-code-eyes) — an open-source (MIT) Claude Code skill that lets Claude see real hardware, displays, and wiring through a camera (Android IP Webcam, Raspberry Pi camera-streamer, or any snapshot URL) and read the frame: to visually verify a rendered panel or check wiring/voltage rails before power-on, catching output no unit test, log, or API can. ~100 lines of bash + a SKILL.md, one-command setup, tested under bash 3.2. Live and in active use (18+ stars, 50+ clones in the first day).