### PR TITLE
Add dorveille and scatterbrain (The Little AI Company)

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 <summary><strong>Productivity and Collaboration</strong></summary>
 
 - [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - Document processing: convert, OCR, and redact PII
+- [The-Little-AI-Company/scatterbrain](https://github.com/The-Little-AI-Company/scatterbrain) - Divergent ideation via parallel isolated branches under distorted cognitive frames, then a critic pass
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
@@ -545,6 +546,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 <summary><strong>Development and Testing</strong></summary>
 
 - [muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams) - Generate hand-drawn Excalidraw diagrams from prompt
+- [The-Little-AI-Company/dorveille](https://github.com/The-Little-AI-Company/dorveille) - Sleep architecture for long sessions: pressure-driven states, fresh-eyes review, auditable hypnogram log
 - [coderabbitai/skills](https://github.com/coderabbitai/skills) - Code review and PR autofix workflows
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina


### PR DESCRIPTION
Adds two MIT-licensed community skills from The Little AI Company:

- **dorveille** (Development and Testing) — gives long agent sessions a sleep architecture: six pressure-driven states, isolated divergence at decision forks, authorship-stripped review before "done", and an auditable hypnogram log on disk. Installable via `npx skills add the-little-ai-company/dorveille` (verified working). Site: https://the-little-ai-company.github.io/dorveille/

- **scatterbrain** (Productivity and Collaboration) — divergent ideation for open-ended problems: parallel isolated branches, each under a deliberately distorted cognitive frame, then a separate critic pass that scores, clusters, and flags trap ideas. Built Zo-native (real child-session isolation) with SKILL.md fallback for other agents; `npx skills add the-little-ai-company/scatterbrain` verified working. Core concept credited to UditAkhourii/adhd (MIT).

Both repos exist, are public, and have SKILL.md under 500 lines per the contribution guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GESPHt24J4jy4uLrsat1Bq
