### PR TITLE
feat: add Schedulala agent skill (social media scheduling)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,9 @@ Official skills for ML workflows.
 #### Skills by Typefully
 - [typefully/typefully](https://agent-skill.co/typefully/skills/typefully) - Create, schedule, and publish social media content
 
+#### Skills by Schedulala
+- [schedulala/schedulala-agent](https://github.com/schedulala/schedulala-agent) - Schedule and publish social media posts to 12 platforms with per-platform rules, media handling, analytics, and engagement
+
 #### Skills by Composio
 - [composiohq/composio](https://agent-skill.co/composiohq/skills/composio) - Connect AI agents to 1000+ external apps with managed authentication
 


### PR DESCRIPTION
Adds the official [Schedulala](https://schedulala.com) agent skill to **Business, Productivity & Marketing**, next to the other social-content entries.

**[schedulala/schedulala-agent](https://github.com/schedulala/schedulala-agent)** — schedule and publish social media posts to 12 platforms (Twitter/X, Instagram, TikTok, LinkedIn, YouTube, Facebook, Threads, Bluesky, Pinterest, Mastodon, Telegram, Google Business Profile).

Follows the SKILL.md standard: `name`/`description` frontmatter tuned for auto-discovery, a lean playbook body (safe publish workflow: draft → validate/preview → confirm → publish → verify), progressive-disclosure `references/` (per-platform rules, media protocol, CLI, connector widgets), and ready-to-adapt example payloads. Installable via `npx skills add schedulala/schedulala-agent` (verified) or the Claude Code plugin marketplace; pairs with Schedulala's hosted MCP connector and CLI. MIT licensed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)