### PR TITLE
Add agent-affect-skills to Community Skills (Development and Testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [Ansvar-Systems/agent-affect-skills](https://github.com/Ansvar-Systems/agent-affect-skills) - End-of-task feedback channels: whine (friction), cringe (UX rot), protect (load-bearing code)
 </details>
 
 <details>


### PR DESCRIPTION
Adds [Ansvar-Systems/agent-affect-skills](https://github.com/Ansvar-Systems/agent-affect-skills): four skills that end substantial coding/review/audit tasks with one subjective finding per emotional channel (or an explicit null) — whine for friction and bugs, cringe for UX that works but shouldn't ship, protect for load-bearing code a cleanup pass would delete, plus a combined check-in.

Meets the quality standards: standard skills/<name>/SKILL.md layout (works with npx skills add), each SKILL.md well under 500 lines, clear instructions with worked examples and documented anti-patterns, repo exists and is active. CC BY 4.0. Background: https://ansvar.eu/blog/agent-affect-channels-whine-cringe-protect