### PR TITLE
Add Shilo/pixellab-pip skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [Shilo/pixellab-pip](https://github.com/Shilo/pixellab-pip) - Route PixelLab MCP/REST to generate, edit, and animate pixel art
 </details>
 
 <details>


### PR DESCRIPTION
Adds **Shilo/pixellab-pip** to Community Skills → *Development and Testing* (appended, matching the existing `- [author/skill](url) - short description` format).

PixelLab Pip is an agent-agnostic router that turns a plain request into the right PixelLab call — MCP tool, REST v2, website/editor, or Aseprite — to generate, edit, and animate pixel-art sprites, tilesets, characters, and cinematics, with credit-cost control.

- Repo (own SKILL.md + references): https://github.com/Shilo/pixellab-pip
- Public and installable; security-audited each release (GitHub Code Scanning + ClawHub).

README-only link addition (no website build change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)