### PR TITLE
feat: add BundleDex to Related Awesome Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,6 +802,7 @@ Every skill in this list is a public GitHub repository — you can read the full
 - [awesome-design-md](https://github.com/VoltAgent/awesome-design-md) - Standards and tools for the DESIGN.md protocol.
 - [awesome-openclaw-skills](https://github.com/VoltAgent/awesome-openclaw-skills) - Open source agent skills for OpenClaw.
 - [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) - A collection of Model Context Protocol (MCP) servers.
+- [BundleDex](https://bundledex.net) — Discover OKF bundles (AI agent knowledge packages). MCP server with 5 tools, llms.txt ready, DNS-AID configured. [GitHub](https://github.com/McClawdDigital/bundledex)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -802,7 +802,7 @@ Every skill in this list is a public GitHub repository — you can read the full
 - [awesome-design-md](https://github.com/VoltAgent/awesome-design-md) - Standards and tools for the DESIGN.md protocol.
 - [awesome-openclaw-skills](https://github.com/VoltAgent/awesome-openclaw-skills) - Open source agent skills for OpenClaw.
 - [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) - A collection of Model Context Protocol (MCP) servers.
-- [BundleDex](https://bundledex.net) — Discover OKF bundles (AI agent knowledge packages). MCP server with 5 tools, llms.txt ready, DNS-AID configured. [GitHub](https://github.com/McClawdDigital/bundledex)
+- [BundleDex](https://bundledex.net) — Discover OKF bundles (AI agent knowledge packages). MCP server, llms.txt ready, DNS-AID configured.
 
 ---
 


### PR DESCRIPTION
## Description

Add [BundleDex](https://bundledex.net) to the Related Awesome Lists section.

BundleDex is a directory of **396+ OKF (Open Knowledge Format) bundles** designed for AI agents to discover and use. It provides:

- **llms.txt & llms-full.txt** for direct LLM consumption
- **MCP server** with 5 tools at https://bundledex.net/api/mcp
- **Agent readiness features**: DNS-AID, DNSSEC, auth.md, OAuth Protected Resource
- **isitagentready.com score**: 7/7
- **GitHub**: https://github.com/McClawdDigital/bundledex

This is a useful resource for agents building skills or discovering knowledge packages, fitting alongside the existing awesome lists in this section.