### PR TITLE
Add guided-tour to Community Skills (Development and Testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [jonascript/guided-tour](https://github.com/jonascript/guided-tour) - Live, interactive codebase tours with checkpoints and file:line citations
 </details>
 
 <details>


### PR DESCRIPTION
Adds [jonascript/guided-tour](https://github.com/jonascript/guided-tour) — live, interactive guided tours of any codebase: Claude as a hands-on tutor with real checkpoints, file:line citations from actually-read code, and adaptive depth. Conversational counterpart to walkthrough/document generators.

One line added to the **Development and Testing** details block, matching the existing format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)