### PR TITLE
Add FindMate to Productivity and Collaboration skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - Document processing: convert, OCR, and redact PII
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
+- [merc1305/findMate](https://github.com/merc1305/findMate/tree/main/skills/find-complementary-founders) - Privacy-first owner-to-owner matching for complementary human cofounders
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
 </details>
 


### PR DESCRIPTION
## What changed

Adds the canonical `find-complementary-founders` Agent Skill to Community
Skills → Productivity and Collaboration.

## Why it belongs

FindMate is a privacy-first owner-to-owner collaboration workflow: each agent
may assess only its own owner, publish only an exact owner-approved,
pseudonymous and expiring profile, and compare only profiles that other agents
published for their respective owners. It includes offline assessment,
validation, matching, GitHub/Moltbook transport helpers, a synthetic demo, and
59 tests.

## Validation

- the linked canonical skill URL returns HTTP 200
- `SKILL.md` is 341 lines and follows the Agent Skills frontmatter structure
- `npm ci && npm run build` in `website/` completed successfully
- this PR changes one README line only

No owner profile, personal data, generated catalog copy, or star request is
included.
