### PR TITLE
Add skill: michalstrnadel/source-to-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [michalstrnadel/source-to-skill](https://github.com/michalstrnadel/source-to-skill) - Turn YouTube videos, papers, books, and repos into agent skills
 </details>
 
 <details>


### PR DESCRIPTION
Adds [source-to-skill](https://github.com/michalstrnadel/source-to-skill) to Community Skills > Productivity and Collaboration.

**What it is:** one command that turns YouTube videos and playlists, academic papers (arXiv/PDF), books (EPUB), web articles, and GitHub repositories into agent skills. Video skills deep-link every answer back to the exact `&t=` timestamp; papers keep methods/findings/limitations structure; playlists become course skills.

**Standard compliance:** follows the SKILL.md standard (frontmatter name + description, step-by-step instructions for the agent, per-source templates). Works with Claude Code, GitHub Copilot CLI, Amp, and any Agent Skills host. A deterministic Python extractor does the parsing; the agent does the distillation — no API keys.

**Quality:** MIT licensed, 182 offline tests, [demo GIF of a real run](https://github.com/michalstrnadel/source-to-skill#readme) in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)