### PR TITLE
Add xiaopixuan skills-public

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 <summary><strong>Development and Testing</strong></summary>
 
 - [muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams) - Generate hand-drawn Excalidraw diagrams from prompt
+- [xiaopixuan/skills-public](https://github.com/xiaopixuan/skills-public) - Public Codex skills catalog with editable draw.io diagrams, skill design review, example prompts, and review scorecards
 - [coderabbitai/skills](https://github.com/coderabbitai/skills) - Code review and PR autofix workflows
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina


### PR DESCRIPTION
## Summary\n\nAdds xiaopixuan/skills-public to the Development and Testing section.\n\nThe catalog includes public Codex skills for:\n- editable draw.io / diagrams.net diagram generation\n- skill design review and scoring\n- example prompts, editable diagram sources, and review scorecards\n\n## Link\n\nhttps://github.com/xiaopixuan/skills-public