### PR TITLE
Add ToruGuy/smalltalk (new Personal Development category)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ That's it. No installation. No configuration. No coding required.
   - [Productivity and Collaboration](#productivity-and-collaboration)
   - [Development and Testing](#development-and-testing)
   - [Context Engineering](#context-engineering)
+  - [Personal Development](#personal-development)
 - [Skill Quality Standards](#skill-quality-standards)
 - [Using Skills](#using-skills)
 - [Creating Skills](#creating-skills)
@@ -557,6 +558,12 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
+</details>
+
+<details>
+<summary><strong>Personal Development</strong></summary>
+
+- [ToruAI/smalltalk](https://github.com/ToruAI/smalltalk) - Daily small talk training: roleplay sparring, honest scoring, real-world missions
 </details>
 
 ---

--- a/README.md
+++ b/README.md
@@ -563,7 +563,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 <details>
 <summary><strong>Personal Development</strong></summary>
 
-- [ToruAI/smalltalk](https://github.com/ToruAI/smalltalk) - Daily small talk training: roleplay sparring, honest scoring, real-world missions
+- [ToruGuy/smalltalk](https://github.com/ToruGuy/smalltalk) - Daily small talk training: roleplay sparring, honest scoring, real-world missions
 </details>
 
 ---


### PR DESCRIPTION
Adds [ToruGuy/smalltalk](https://github.com/ToruGuy/smalltalk) to Community Skills under a new **Personal Development** category (none of the existing categories fit).

**What it is:** daily small talk training for people who spend their days behind a screen — short roleplay sparring in free text with realistic NPCs, honest scoring against a 5-category rubric, one technique to study, and a real-world mission ladder (T1–T4) with streaks. The coach keeps a living profile and names the user's recurring failure patterns over time.

**Quality checklist:**
- Valid `SKILL.md` under `skills/smalltalk/` (Agent Skills format) — installable via `npx skills add ToruGuy/smalltalk`
- Also a Claude Code plugin (`.claude-plugin/plugin.json` + marketplace manifest), passes `claude plugin validate`
- MIT licensed, documented README (EN + PL), versioned releases