### PR TITLE
Add Orkas-AI/video-router skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [Orkas-AI/video-router](https://github.com/Orkas-AI/Orkas-VideoStudio/tree/main/packages/skills/video-router) - Route video requests through deterministic agent production stages
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Add the documented OrkasVideoStudio `video-router` skill under Community Skills → Productivity and Collaboration. The focused skill selects and sequences deterministic stages for an agent-driven video-production request.

## Validation

- direct `SKILL.md` directory URL returns HTTP 200
- the skill is 45 lines and has YAML metadata
- the project installer supports Codex and Claude Code
- `git diff --check` passes

Disclosure: submitted on behalf of the OrkasVideoStudio project.