### PR TITLE
feat: add HTML Docs skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 <summary><strong>Productivity and Collaboration</strong></summary>
 
 - [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - Document processing: convert, OCR, and redact PII
+- [raunaqbn/html-docs-skill](https://github.com/raunaqbn/html-docs-skill) - Turn source material into collaborative HTML docs, narrated videos, or courses
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams


### PR DESCRIPTION
## Summary

Adds the HTML Docs agent skill to **Community Skills → Productivity and Collaboration**.

The skill turns folders, codebases, websites, PDFs, documents, and research topics into source-grounded collaborative HTML documents, narrated explainer videos, or complete courses. It includes a documented `SKILL.md`, real published examples, inspectable production tooling, and an MIT license.

- Skill repository: https://github.com/raunaqbn/html-docs-skill
- Live guide: https://www.html-docs.com/agents
- Showcase: https://www.html-docs.com/showcase

This contribution was prepared with agent assistance and checked against the repository’s contribution guidelines.