### PR TITLE
Add trevhud/rote to Community Skills (Development and Testing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [trevhud/rote](https://github.com/trevhud/rote/tree/main/plugin/skills) - Compile a proven skill into a deterministic pipeline, then serve it as MCP tools
 </details>
 
 <details>


### PR DESCRIPTION
Adds [trevhud/rote](https://github.com/trevhud/rote/tree/main/plugin/skills) to Community Skills > Development and Testing.

The repo ships two SKILL.md-standard skills:

- `compile` - runs the rote CLI over an existing skill (a SKILL.md plus its references) and emits a deterministic pipeline: a pipeline.yaml IR, extracted code modules with per-step tests, and typed LLM-judge signatures for the steps that genuinely need judgment.
- `serve` - wires a compiled pipeline up as MCP tools via `rote register` / `rote serve` and the matching `claude mcp add` command.

So it belongs here on two counts: it is a skill collection in the SKILL.md format, and the thing it operates on is other people's skills. The underlying CLI is open source (Apache-2.0, Python 3.11+, `pip install rote-cli`) and runs locally. Compiled output targets DBOS, Temporal, Cloudflare Workflows, Inngest, or plain Python/TypeScript.

- Repo: https://github.com/trevhud/rote
- Docs: https://roteskills.com

This is a new project without significant traction yet. Only the README entry changed, so there are no `website/` regressions to check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)