### PR TITLE
Add Fact-Check-X to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [ASI2030/fact-check-x-complete](https://github.com/ASI2030/Fact-Check-X/tree/main/skills/fact-check-x-complete) - Compare AI answers and verify claims against authoritative evidence
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Add the complete Fact-Check-X skill to **Community Skills → Productivity and Collaboration**.

Fact-Check-X compares complete answers and citations from multiple AI services, then verifies atomic claims against authoritative evidence.

## Verification

- public source: https://github.com/ASI2030/Fact-Check-X/tree/main/skills/fact-check-x-complete
- Apache-2.0 licensed
- standard `SKILL.md` layout
- cold-installed from the public deep link and verified as a complete 94-file tree
- `git diff --check` passes
- source link returns HTTP 200