### PR TITLE
Add alsoleg89/doubt evidence-mapping skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
-- [alsoleg89/doubt](https://github.com/alsoleg89/doubt/tree/main/skill/doubt) - Build source-grounded evidence maps with explicit contradictions and missing evidence
+- [alsoleg89/doubt](https://github.com/alsoleg89/doubt/tree/main/skills/doubt) - Build source-grounded evidence maps with explicit contradictions and missing evidence
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [alsoleg89/doubt](https://github.com/alsoleg89/doubt/tree/main/skill/doubt) - Build source-grounded evidence maps with explicit contradictions and missing evidence
 </details>
 
 <details>


### PR DESCRIPTION
## What changed

Adds `alsoleg89/doubt` to the Productivity and Collaboration community-skills section.

## Why it belongs

Doubt is a portable Agent Skill for turning contested questions into source-grounded evidence maps. It preserves supporting, contradicting, and qualifying evidence plus explicit unknowns, with every evidence edge linked to a dated source region.

The repository includes:

- a zero-dependency validator and self-contained HTML renderer;
- explicit source retrieval and excerpt verification with byte-bound receipts;
- a local-only browser playground;
- two public evidence maps;
- a reusable GitHub Action;
- a preregistered map-vs-memo reader study;
- a 21-case adversarial evidence-contract benchmark;
- a frozen five-client Agent Skills portability protocol with one published client result.

Current portability audit:

https://alsoleg89.github.io/doubt/examples/agent-skills-portability.html

## Verification

- Confirmed the linked `skills/doubt` publisher path and public examples resolve.
- Verified all repository skill mirrors are byte-identical to the canonical payload.
- Ran the current project suite: 49 automated tests plus 21/21 adversarial contract cases.
- Validated the submitted GitHub Copilot portability result.
- Kept the catalog change to one README entry in the existing community category.

Try the zero-install playground:

https://alsoleg89.github.io/doubt/playground/