### PR TITLE
Add Codex engineering-loop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [Phelan164/codex-howto engineering-loop](https://github.com/Phelan164/codex-howto/tree/main/skills/engineering-loop) - Evidence-first coding loop with scoped changes, testing, review, handoff, and efficiency measurement
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Add the `engineering-loop` skill from
[`Phelan164/codex-howto`](https://github.com/Phelan164/codex-howto) to
Community Skills → Development and Testing.

The skill provides an evidence-first coding loop:

1. scope the task;
2. reproduce or establish a baseline;
3. make the smallest coherent change;
4. run focused and required checks;
5. perform findings-first review; and
6. hand off observable evidence.

It also includes an engineering playground, measurement rubric, sample run
data, and deterministic summarizer in the source repository.

## Why it fits

- Valid, public `SKILL.md`
- Focused development and testing workflow
- Works with Codex and Agent Skills-compatible coding assistants
- Documents verification, failure handling, review, and limitations
- MIT licensed
- Available through [skills.sh](https://skills.sh/phelan164/codex-howto/engineering-loop)

## Verification

- Confirmed there was no existing `Phelan164/codex-howto` entry
- `git diff --check`
- `cd website && npm ci && npm run build`

Only the English source index changes; no generated files or unrelated
translations are modified.
