### PR TITLE
feat: add Localize SaaS for China skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
+- [stomeonst/localize-saas-for-china](https://github.com/stomeonst/localize-saas-for-china) - Evidence-led Chinese positioning, localization, launch copy, and QA
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adds Localize SaaS for China to Community Skills under Marketing.

The public skill provides evidence-led Chinese positioning, localization, launch copy, and QA workflows. Its repository includes a working SKILL.md, focused references, and concrete examples.

## Verification

* The skill repository and documentation are publicly accessible.
* `git diff --check` passed.
* `npm run build` passed in the website directory.