### PR TITLE
Add suede-marketing-plan skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
+- [JasonColapietro/suede-marketing-plan](https://github.com/JasonColapietro/suede-creator-skills/tree/main/skills/suede-marketing-plan) - Build evidence-based 90-day and 12-month marketing operating plans sized to the team, budget, and stage
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adds suede-marketing-plan to the Community Skills marketing section.

The skill builds evidence-based 90-day and 12-month marketing operating plans sized to the available team, budget, stage, and constraints.

## Verification

- Confirmed the direct SKILL.md path is public and returns 200.
- Ran the website production build successfully.
- Ran git diff --check.