### PR TITLE
Add cowork-to-code-bridge to Community Skills → Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [abhinaykrupa/cowork-to-code-bridge](https://github.com/abhinaykrupa/cowork-to-code-bridge) - Run tasks on your own Mac/Linux box from a sandboxed agent session via a file-based queue
 </details>
 
 <details>


### PR DESCRIPTION
Adds **[cowork-to-code-bridge](https://github.com/abhinaykrupa/cowork-to-code-bridge)** under *Community Skills → Development and Testing*.

### What it does

A sandboxed agent session (Claude Cowork, or any MCP-aware agent) can't touch the user's real machine — no builds, no `git push`, no Docker, no local test runs. This skill bridges that gap with an async file-based queue over a shared directory: the agent queues a task, a small local daemon executes it on the user's Mac or Linux box, and the result comes back. Local-first, no tunnel or inbound port.

### Against the list's Skill Quality Standards

| Standard | How it's met |
|---|---|
| Clear instructions | `SKILL.md` is a numbered Step 1–5 flow, starting with connect |
| Appropriate scope | One task: hand work to Claude Code on the local machine |
| Working examples | Runnable Python snippets per step, not pseudocode |
| Documented trade-offs | SECURITY.md documents the allowlist model and states redaction is best-effort |
| Size limit | `SKILL.md` is 400 lines, under the 500-line bar |
| Tested | 440 tests in CI across macOS + Linux on Python 3.10/3.11/3.12 |

MIT licensed. One-line entry, alphabetical position preserved within the block, no other files touched.