### PR TITLE
Add Handover context engineering skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
+- [44-pixels/handover-mcp](https://github.com/44-pixels/handover-mcp/tree/main/skills) - Publish, resume, review, and govern versioned context through MCP or CLI
 </details>
 
 ---


### PR DESCRIPTION
## Summary

Adds the open Handover skill collection to Context Engineering.

The four source-visible skills cover publishing versioned context, resuming work from another actor, reviewing artifacts with annotations, and governance through Handover MCP or CLI.

## Quality checks

- Public source: https://github.com/44-pixels/handover-mcp/tree/main/skills
- Each skill contains a standard SKILL.md
- The collection is tested against the published MCP/CLI workflow
- The link returns HTTP 200
- The entry is placed in the existing Context Engineering category

The description is intentionally concise and links directly to source.