### PR TITLE
Add attention-control to Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [aaddrick/attention-control](https://github.com/aaddrick/attention-control) - Air traffic control discipline for coding-agent output, tuned for ADHD reading
 </details>
 
 <details>


### PR DESCRIPTION
One entry, appended to **Community Skills → Development and Testing**.

**[aaddrick/attention-control](https://github.com/aaddrick/attention-control)** — air traffic control discipline for coding-agent output, tuned for ADHD reading.

ATC phraseology exists because a distracted human under load mishears an instruction. Aviation solved it with two disciplines: controlled vocabulary, so each word means one thing, and fixed message shape, so the instruction leads and the background trails. The skill ports both to a coding agent.

**Why this section.** It shapes the quality of what the agent writes back, the same category as `taste-skill` already here. Context Engineering is memory and compression, which this is not.

**Against your quality standards.**
- Clear instructions: 11 numbered shape rules and a language layer with explicit word, grammar, and sentence limits.
- Appropriate scope: one focused job, the prose the agent writes itself. Code, commands, paths, identifiers, error messages, and quoted text stay verbatim.
- Working examples: a 10-row before/after table in the skill, plus a full worked example in the README.
- Documented trade-offs: a precedence section resolves the four places the two layers collide, and six documented cases override the defaults. The README states that nothing outside the model enforces an output style.
- Size limit: `SKILL.md` is 186 lines, under your 500.
- Tested: an eval harness scores it against an unstyled baseline across 24 cases and 6 dimensions, with blind grading and order-reversed double scoring.

**Provenance.** The shape layer adapts [`i-have-adhd`](https://github.com/ayghri/i-have-adhd) by Ayoub G. (MIT). The language layer derives from [L1nefeed's `asd-ste100` output style](https://gist.github.com/L1nefeed/4164ecaaf77879e76dca3c06f142f1c2), condensed from ASD-STE100 Simplified Technical English, Issue 9. The project reproduces no text from the ASD specification, and the ASD does not certify, endorse, or sponsor it.