### PR TITLE
Add skill: morluto/rea

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [morluto/rea](https://github.com/morluto/rea/tree/main/skills/reverse-engineer-anything) - Agent-driven reverse engineering across binaries, managed apps, Electron, and browsers
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adds [morluto/rea](https://github.com/morluto/rea/tree/main/skills/reverse-engineer-anything) to Community Skills → Development and Testing.

The linked public skill provides a focused workflow for reverse engineering native binaries, managed applications, Electron/JavaScript packages, and browser runtimes with REA's local CLI and MCP tools. The PR indexes the existing skill rather than copying its files.

## Validation

- Confirmed the public `SKILL.md` and supporting references are present.
- Checked the current README and GitHub issues/PRs for a duplicate REA entry.
- Ran `npm run build` in `website/` successfully.