### PR TITLE
Add liquid-glass-skills (Liquid Glass for SwiftUI/UIKit/AppKit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [YordiLorenzo/liquid-glass-skills](https://github.com/YordiLorenzo/liquid-glass-skills) - Liquid Glass material and motion for SwiftUI/UIKit/AppKit, availability-pinned and SDK-verified
 </details>
 
 <details>


### PR DESCRIPTION
Adds [YordiLorenzo/liquid-glass-skills](https://github.com/YordiLorenzo/liquid-glass-skills) to Community Skills → Development and Testing.

Two complementary skills for Apple's Liquid Glass design system (iOS 26+/macOS 26 Tahoe through the iOS 27 betas): `liquid-glass` covers the material (variants, containers, toolbars, UIKit/AppKit glass, accessibility, fallbacks, review checklist) and `liquid-glass-motion` covers motion (morphing, animation fundamentals, Reduce Motion gating, Metal shaders, Instruments profiling).

Per the quality standards: both SKILL.md files are routers under 150 lines with per-topic references, instructions are actionable with working examples, trade-offs are documented, and every rule carries an availability floor plus a confidence tag verified against Apple documentation and SDK interfaces. Installable via `npx skills add YordiLorenzo/liquid-glass-skills` or as a Claude Code plugin marketplace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6NK1ZtgcdnZyfdm8Y2TTv