### PR TITLE
Fix attribution: two rows both point at product-on-purpose/pm-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,17 +451,17 @@ Install from [better-auth/skills](https://github.com/better-auth/skills).
 |-------|-------------|
 | [agent-gtm-skills](https://github.com/chadboyda/agent-gtm-skills) | 18 go-to-market skills: pricing, outbound, SEO, ads, retention, and ops |
 
-#### Product Manager Skills by Dean Peters
+#### Product Management Skills by Product on Purpose
 
 | Skill | Description |
 |-------|-------------|
-| [pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 product management skills covering discovery, definition, delivery, and optimization |
+| [pm-skills](https://github.com/product-on-purpose/pm-skills) | 68 product management skills covering discovery, definition, delivery, and iteration, with 6 sub-agents and 12 workflows |
 
 #### Product Management Skills by Pawel Huryn
 
 | Skill | Description |
 |-------|-------------|
-| [pm-skills-huryn](https://github.com/product-on-purpose/pm-skills) | Advanced product management frameworks, OKRs, and strategy skills |
+| [pm-skills-huryn](https://github.com/phuryn/pm-skills) | Advanced product management frameworks, OKRs, and strategy skills |
 
 #### Skills by Garry Tan (gstack)
 


### PR DESCRIPTION
## Summary

Two rows in the Product Management section currently point at the same URL, `product-on-purpose/pm-skills`, under two different authors' names. This PR corrects the attribution for all three projects involved and refreshes one stale count.

I am the author of `product-on-purpose/pm-skills`, so I want to be upfront that one of these three fixes benefits my project. The other two correct rows that point at my repo but should not.

## What is wrong today

```text
#### Product Manager Skills by Dean Peters
| [pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 product management skills ... |

#### Product Management Skills by Pawel Huryn
| [pm-skills-huryn](https://github.com/product-on-purpose/pm-skills) | Advanced product management frameworks ... |
```

Both rows link to my repo. Neither attribution is correct:

- The row under **Dean Peters** links to my project, not to `deanpeters/Product-Manager-Skills`.
- The row labelled **pm-skills-huryn** links to my project, not to `phuryn/pm-skills`.

For context on how this happened: the entry I originally submitted in #39 was a single row labelled `product-on-purpose/pm-skills`. It looks like the April reorganisation into per-author sections split it across two headings and reused the URL.

## What this PR changes

1. Renames the heading over my row from "Product Manager Skills by Dean Peters" to "Product Management Skills by Product on Purpose", since the linked repo is mine.
2. Repoints the row labelled `pm-skills-huryn` at `https://github.com/phuryn/pm-skills`, which is the project that label refers to.
3. Updates my entry's skill count from 24 to 68, which is current as of v2.31.1, and adds the sub-agent and workflow counts.

Three lines changed. Nothing is added or deleted.

## One thing for you to decide

Dean Peters' and Pawel Huryn's skills already appear individually further up the file, around lines 364 to 377, linked to their correct repos. So the two collection-level rows here may be redundant with those. I have left both in place rather than removing another project's entry, but if you would rather consolidate, that is your call and I am happy to follow up with whichever shape you prefer.

## About the project

`product-on-purpose/pm-skills` is a library of 68 product management skills covering discovery, definition, delivery, and iteration, plus 6 sub-agents, 12 multi-skill workflows, and 200+ sample outputs. Every skill is held to a contract validated in CI and versioned with SemVer, which is why the counts in this entry can be relied on going forward. Apache 2.0, follows the agentskills.io specification.
