### PR TITLE
Add Terminalbox Codex Remote SSH skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 
 - [muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams) - Generate hand-drawn Excalidraw diagrams from prompt
 - [coderabbitai/skills](https://github.com/coderabbitai/skills) - Code review and PR autofix workflows
+- [Anchras/configure-codex-remote-ssh](https://github.com/Anchras/terminalbox-tools/tree/main/plugins/codex-remote-ssh/skills/configure-codex-remote-ssh) - Configure and verify Codex against a paid Terminalbox pane over key-only SSH
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop


### PR DESCRIPTION
## What changed

Adds `Anchras/configure-codex-remote-ssh` to the Community Skills → Development and Testing section.

## Why

The skill gives Codex and other Agent Skills clients a focused, inspectable workflow for configuring a persistent remote development host over key-only SSH. It verifies the published gateway fingerprint, preserves unrelated SSH configuration, never reads private-key material, and stops on host-key mismatches.

The linked skill is 99 lines, follows the `SKILL.md` format, is publicly reviewable, and includes install, verification, troubleshooting, and safety boundaries.

## Validation

- `git diff --check`
- `npm ci`
- `npm run build` in `website/`

The website build completed successfully. The dependency audit reported seven existing advisories; this README-only change does not modify dependencies or lockfiles.
