### PR TITLE
Add setup-open-index context engineering skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,6 +554,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 <details>
 <summary><strong>Context Engineering</strong></summary>
 
+- [DrDroidLab/setup-open-index](https://github.com/DrDroidLab/open-index/blob/main/skills/setup-open-index/SKILL.md) - Set up structured context graphs with hybrid search and read/write MCP access
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors


### PR DESCRIPTION
## Summary

Adds DrDroidLab/setup-open-index under **Community Skills → Context Engineering**.

The skill is a self-contained SKILL.md that guides an agent through installing Open Index, creating a typed domain context graph, configuring MCP, verifying read/write tools with synthetic data, and applying production guardrails.

- [x] Portable SKILL.md format
- [x] Clear trigger and scoped workflow
- [x] Concrete setup and verification steps
- [x] Public MIT-licensed repository

Skill: https://github.com/DrDroidLab/open-index/blob/main/skills/setup-open-index/SKILL.md

Disclosure: this is an affiliated submission from the Open Index team.