### PR TITLE
feat: add Shuwanito/SkillsMP (education and corporate training skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,6 +559,12 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
 </details>
 
+<details>
+<summary><strong>Education and Corporate Training</strong></summary>
+
+- [Shuwanito/SkillsMP](https://github.com/Shuwanito/SkillsMP) - Education and corporate training skills with per-skill evals and certification: clinical case generation, code review, sales coaching
+</details>
+
 ---
 
 ## Skill Quality Standards


### PR DESCRIPTION
Adds a new **Education and Corporate Training** category under Community Skills with [Shuwanito/SkillsMP](https://github.com/Shuwanito/SkillsMP) — a collection of SKILL.md skills (agentskills.io standard) for education and corporate training: clinical case generation, code review, retail sales coaching, AI coaching.

Quality standards checklist:
- SKILL.md format with name/description frontmatter, all under 500 lines
- Each skill ships evals (5+ test cases) and goes through a 4-level internal certification program
- Skills include Common Rationalizations and Verification sections (documented trade-offs and evidence-based completion checks)
- Built and used by a real multi-agent ecosystem (111 agents / 31 departments) that exercises them daily

README-only change — no website/ code touched. Happy to move the entry to an existing category if you prefer not to add a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)