### PR TITLE
Add skill: Lwu0rup/launchsmith

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [Lwu0rup/launchsmith](https://github.com/Lwu0rup/gh-launchsmith/tree/main/skills/launchsmith) - Evidence-first open-source launch audits and release preparation
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adds LaunchSmith to **Community Skills → Development and Testing**.

LaunchSmith audits an open-source repository from inspectable files and GitHub metadata, fixes evidence-backed launch gaps, and prepares reviewed release/community materials without inventing unsupported claims.

- Skill: https://github.com/Lwu0rup/gh-launchsmith/tree/main/skills/launchsmith
- Documentation and self-audit: https://github.com/Lwu0rup/gh-launchsmith
- License: MIT

## Verification

- `SKILL.md` passes the official skill validator
- repository CI passes on Node.js 20, 22, and 24
- `npm run build` completed successfully in `website/` for this contribution