### PR TITLE
Add Skills by HumanPen

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,9 @@ Official skills for ML workflows.
 - [better-auth/create-auth](https://agent-skill.co/better-auth/skills/create-auth) - Create authentication setup with Better Auth
 - [better-auth/twoFactor](https://agent-skill.co/better-auth/skills/twoFactor) - Two-factor authentication with Better Auth
 
+#### Skills by HumanPen
+- [humanpen/humanpen-skill](https://github.com/humanpen/humanpen-skill) - Rewrites Word/PowerPoint/PDF documents to read as human-written and lower AI-detection scores
+
 <details>
 <summary><strong>Marketing Skills by Corey Haines</strong></summary>
 

--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ Official skills for ML workflows.
 - [better-auth/twoFactor](https://agent-skill.co/better-auth/skills/twoFactor) - Two-factor authentication with Better Auth
 
 #### Skills by HumanPen
-- [humanpen/humanpen-skill](https://github.com/humanpen/humanpen-skill) - Rewrites Word/PowerPoint/PDF documents to read as human-written and lower AI-detection scores
+- [humanpen/humanpen-skill](https://github.com/humanpen/humanpen-skill) - Rewrites .docx/.pptx documents to read as human-written and lower AI-detection scores
 
 <details>
 <summary><strong>Marketing Skills by Corey Haines</strong></summary>


### PR DESCRIPTION
Adds a **Skills by HumanPen** block under **Business, Productivity & Marketing**.

[humanpen/humanpen-skill](https://github.com/humanpen/humanpen-skill) rewrites Word/PowerPoint/PDF documents to read as human-written and lower AI-detection scores, keeping every fact, number, table and all formatting intact. Ships `SKILL.md`; Apache-2.0.