### PR TITLE
Add Social Content Monitor Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,8 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [wulitou-shubing/video-audio-transcribe](https://github.com/wulitou-shubing/social-content-monitor-skills/tree/main/skills/video-audio-transcribe) - Transcribe authorized video and audio into timestamped TXT and SRT
+- [wulitou-shubing/social-content-monitor-to-lark](https://github.com/wulitou-shubing/social-content-monitor-skills/tree/main/skills/social-content-monitor-to-lark) - Monitor creator posts and write deduplicated metadata and transcripts to Lark
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Add two open-format Agent Skills to the Productivity and Collaboration community section:

- `video-audio-transcribe` for authorized media transcription with timestamped TXT and SRT output
- `social-content-monitor-to-lark` for creator-feed monitoring, stable-ID deduplication, and structured Lark Base delivery

Both Skills live in the same public MIT-licensed repository and have focused `SKILL.md` instructions, runnable scripts or validation, documented safety boundaries, examples, and Chinese/English project documentation.

## Verification

- Installed both Skills from a clean local Git repository with the skills.sh CLI
- Ran the source repository's Skill structure and Python validation
- Ran `npm run build` successfully in this repository's `website` directory
