### PR TITLE
Add tidy-my-stars skill bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [z116123123x/tidy-my-stars](https://github.com/z116123123x/tidy-my-stars) - Two-skill bundle for organizing GitHub Stars into overlapping Lists and review reports
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

- add `z116123123x/tidy-my-stars` to Community Skills → Productivity and Collaboration
- link the canonical repository root so its `tidy-my-stars` and `explain-my-stars` companion skills remain together
- describe the bundle without claiming community adoption

## Verification

- `cd website && npm ci && npm run build`