### PR TITLE
Add skill: Yuuqq/know-skills (css-professor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [Yuuqq/know-skills](https://github.com/Yuuqq/know-skills) - Social science professor: explain, mentor research, review methods (EN/中文)
 </details>
 
 <details>


### PR DESCRIPTION
Adds **[Yuuqq/know-skills](https://github.com/Yuuqq/know-skills)** to Community Skills > Productivity and Collaboration.

**What it is:** an Agent Skill that answers like a computational social science professor — it routes each question to a stance (classroom teacher / research mentor / methodology reviewer), caps answer depth, and enforces a truth-source vs. measurement-artifact discipline so the model stops reading causality into platform metrics. Bilingual EN/中文, including a Chinese academic register.

**Quality standards checklist:**
- SKILL.md standard with name + description frontmatter, instructions, and routing tables
- Before/after examples: three worked comparisons in [docs/before-after-demos.md](https://github.com/Yuuqq/know-skills/blob/master/docs/before-after-demos.md)
- Tested: 48 offline contract tests + 12 golden prompts run in CI (Ubuntu + Windows), plus an optional live-model eval harness
- MIT licensed, works with Claude Code / Cursor / Codex / Copilot

Link verified. Happy to adjust category or wording.

Made with [Cursor](https://cursor.com)