### PR TITLE
feat: add Meanwhile skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [vaddisrinivas/meanwhile](https://github.com/vaddisrinivas/meanwhile/tree/main/meanwhile) - Offer one optional side quest while substantial agent work continues
 </details>
 
 <details>


### PR DESCRIPTION
Adds [Meanwhile](https://github.com/vaddisrinivas/meanwhile/tree/main/meanwhile) to Community Skills → Productivity and Collaboration.

Meanwhile is a focused Agent Skill that offers one optional, bounded side quest while substantial agent work continues. The repository also includes a static, curlable quest catalogue and native Gemini CLI and Claude Code packaging.

Validation:
- Source `SKILL.md` validated
- `npm run build --prefix website` passed
- `git diff --check` passed
- MIT licensed; no account, telemetry, or completion tracking

Note: dependency installation reported 7 pre-existing audit findings (1 low, 6 high); no dependency files were changed.