### PR TITLE
Add find-files-with-everything CLI skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [DerrickZeng33/find-files-with-everything-cli](https://github.com/DerrickZeng33/find-files-with-everything-cli) - Fast, token-conscious Windows file discovery with Everything CLI
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

- add `find-files-with-everything-cli` to Community Skills under Development and Testing
- describe its Windows file-discovery and token-conscious result-capping focus

## Verification

- `git diff --check`
- `npm run build` in `website/` (passes)

The skill is read-only by default and routes unknown or cross-drive searches to Voidtools Everything CLI while retaining direct-path and ripgrep searches for known locations.