### PR TITLE
feat: add using-lwc skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
+- [JanYork/using-lwc](https://github.com/JanYork/using-lwc) - Persistent project memory with verified document and code graphs
 </details>
 
 ---


### PR DESCRIPTION
Adds `JanYork/using-lwc` to Community Skills > Context Engineering.

Validation:
- Source URL returns HTTP 200
- `website`: `next build --webpack` passed (WASM fallback used because the native SWC binary was unavailable locally)