### PR TITLE
feat: add Mydentify intent discovery skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 
 - [BrianRWagner/ai-marketing-skills](https://github.com/BrianRWagner/ai-marketing-skills) - 17 marketing frameworks for outreach and audits
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
+- [mitdralla/mydentify-agent-skills](https://github.com/mitdralla/mydentify-agent-skills/tree/main/skills/find-products-by-intent) - Find products in Mydentify by a person's desired outcome with evidence-backed matching and ranking safeguards
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
 </details>

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 
 - [BrianRWagner/ai-marketing-skills](https://github.com/BrianRWagner/ai-marketing-skills) - 17 marketing frameworks for outreach and audits
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
-- [mitdralla/mydentify-agent-skills](https://github.com/mitdralla/mydentify-agent-skills/tree/main/skills/find-products-by-intent) - Find products in Mydentify by a person's desired outcome with evidence-backed matching and ranking safeguards
+- [mitdralla/mydentify-agent-skills](https://mydentify.com/.well-known/agent-skills/find-products-by-intent/SKILL.md) - Find products in Mydentify by a person's desired outcome with evidence-backed matching and ranking safeguards
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
 </details>


### PR DESCRIPTION
## What this adds

This adds the public Mydentify `find-products-by-intent` skill to the Community Skills → Marketing section. The skill helps an agent match a person's desired outcome to published Mydentify intents and return evidence-backed product links.

## Why it fits

- The repository explicitly indexes external `SKILL.md` projects.
- The linked skill is public, self-contained, and based on a real product-discovery workflow.
- It includes clear instructions and ranking safeguards against unsupported claims.
- The source is available without credentials at https://github.com/mitdralla/mydentify-agent-skills/tree/main/skills/find-products-by-intent

No new code or dependency is required in this catalog.
