### PR TITLE
Add SandBase Skills collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 <details>
 <summary><strong>Skill Collections</strong></summary>
 
-- [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills) - 88 installable skills for research, market intelligence, content, social, security, and growth workflows, compatible with Codex and DeepSeek Harness
+- [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills) - 100 installable skills for research, market intelligence, content, social, security, and growth workflows, compatible with Codex, Claude Code, Cursor, Gemini CLI, and DeepSeek Harness
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -518,6 +518,12 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 ## Community Skills
 
 <details>
+<summary><strong>Skill Collections</strong></summary>
+
+- [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills) - 88 installable skills for research, market intelligence, content, social, security, and growth workflows, compatible with Codex and DeepSeek Harness
+</details>
+
+<details>
 <summary><strong>Vector Databases</strong></summary>
 
 - [qdrant/skills](https://github.com/qdrant/skills) - Agent skills for Qdrant vector search, scaling, and performance

--- a/README.md
+++ b/README.md
@@ -520,7 +520,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 <details>
 <summary><strong>Skill Collections</strong></summary>
 
-- [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills) - 100 installable skills for research, market intelligence, content, social, security, and growth workflows, compatible with Codex, Claude Code, Cursor, Gemini CLI, and DeepSeek Harness
+- [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills) - 88 installable skills for research, market intelligence, content, social, security, and growth workflows, compatible with Codex, Claude Code, Cursor, Gemini CLI, and DeepSeek Harness
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Add `sandbaseai/sandbase-skills` under a new Community Skills → Skill Collections subsection.

The repository contains 88 installable `SKILL.md` bundles for research, market intelligence, content, social, security, and growth workflows. It includes a machine-readable index, documented examples, safety guidance, and installers for Codex, Claude Code, Cursor, Gemini CLI, and DeepSeek Harness.

Stable release: https://github.com/sandbaseai/sandbase-skills/releases/tag/v0.2.1

## Quality checks

- official Skills CLI discovered 88 Skills and installed `twitter-intelligence` successfully
- repository regression test confirms 88 README entries match 88 installable directories
- confirmed the README documents real use cases, examples, compatibility, permissions, and validation commands
- `git diff --check`
- `cd website && npm run build`

Disclosure: this contribution was prepared with AI assistance for the SandBase project.