### PR TITLE
Add riffkit skill under Business, Productivity & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,9 @@ Official skills for ML workflows.
 - [better-auth/create-auth](https://agent-skill.co/better-auth/skills/create-auth) - Create authentication setup with Better Auth
 - [better-auth/twoFactor](https://agent-skill.co/better-auth/skills/twoFactor) - Two-factor authentication with Better Auth
 
+#### Skills by Riffkit
+- [riffkit/skill](https://github.com/riffkit/skill) - Rebuild a short video that already performed into your own product video
+
 <details>
 <summary><strong>Marketing Skills by Corey Haines</strong></summary>
 


### PR DESCRIPTION
Adds one `#### Skills by Riffkit` block with a single entry, following the vendor-section pattern already used in that section.

- **Skill exists and is live** — [riffkit/skill](https://github.com/riffkit/skill) (`riffkit/SKILL.md`, MIT), also served at https://riffkit.ai/SKILL.md.
- **What it does** — takes a short video that already performed and rebuilds its formula (hook, pacing, emotional beats) into a video for your own product.
- **Against your "keep SKILL.md under 500 lines" guidance: mine does not meet it — 970 lines.** It is the full protocol for a live API (endpoints, task states, error handling) rather than a prompt-style skill. Flagging it rather than hoping it goes unnoticed; if that bar is firm, close this and I will not argue.
- Needs a Riffkit account to render (free allowance to try).

🤖 Generated with [Claude Code](https://claude.com/claude-code)