### PR TITLE
feat: add agent-qa skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 <details>
 <summary><strong>Development and Testing</strong></summary>
 
+- [vostride/agent-qa](https://github.com/vostride/agent-qa) - Three skills for authoring natural-language web and mobile tests, triaging failures, and debugging fixes with MCP evidence
 - [muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams) - Generate hand-drawn Excalidraw diagrams from prompt
 - [coderabbitai/skills](https://github.com/coderabbitai/skills) - Code review and PR autofix workflows
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition


### PR DESCRIPTION
## Summary

Adds `vostride/agent-qa` under **Community Skills → Development and Testing**. The repository provides three focused Agent Skills for authoring natural-language web/mobile tests, triaging failed runs from evidence, and applying narrow debug fixes through agent-qa's MCP surface.

## Validation

- `node skills/scripts/validate-skills.mjs` passes in the source repository.
- The list website's production `npm run build` passes.
- The repository and all three source `SKILL.md` links were verified.
- `git diff --check` passes.

This is an additive README-only listing with no generated-file changes.

Project disclosure: this submission is for agent-qa itself.
