### PR TITLE
feat: add 5dive-ai/skills to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,6 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
 - [5dive-ai/skills](https://github.com/5dive-ai/skills) - Inter-agent comms, knowledge compilation, and fleet diagnostics
-
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -549,6 +549,8 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [5dive-ai/skills](https://github.com/5dive-ai/skills) - Inter-agent comms, knowledge compilation, and fleet diagnostics
+
 </details>
 
 <details>


### PR DESCRIPTION
Adds `5dive-ai/skills` to Community Skills -> Development and Testing.

- Repo: https://github.com/5dive-ai/skills (public, MIT, created 2026-04-27)
- 17 skills, each self-contained in a `SKILL.md` with When-to-Use / Instructions / Examples
- Works with the Quick Start flow: `/skills add https://github.com/5dive-ai/skills`

README-only change, so `website/` is untouched and cannot regress.
