### PR TITLE
Add awesome-agentic-ai to Related Awesome Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,6 +802,7 @@ Every skill in this list is a public GitHub repository — you can read the full
 - [awesome-design-md](https://github.com/VoltAgent/awesome-design-md) - Standards and tools for the DESIGN.md protocol.
 - [awesome-openclaw-skills](https://github.com/VoltAgent/awesome-openclaw-skills) - Open source agent skills for OpenClaw.
 - [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) - A collection of Model Context Protocol (MCP) servers.
+- [awesome-agentic-ai](https://github.com/adriannoes/awesome-agentic-ai) - Learning hub of agent skills, prompts, notebooks, and papers for product builders.
 
 ---
 


### PR DESCRIPTION
Adds our hub to Related Awesome Lists, next to the other indexes you already link.

https://github.com/adriannoes/awesome-agentic-ai

It is a curated learning hub (skills for Claude Code, Cursor, and Codex, plus notebooks and papers), not a single SKILL.md. MIT, public, maintained.

I did not add it under Community Skills on purpose.