### PR TITLE
Add skill: eirik-rune/runemap (echorune-radar)

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,12 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 </details>
 
 <details>
+<summary><strong>Live Data and Sensing</strong></summary>
+
+- [eirik-rune/runemap](https://github.com/eirik-rune/runemap/tree/main/skills/echorune-radar) - Weather and a radar map drawn as text characters, one HTTP request, no image to look at
+</details>
+
+<details>
 <summary><strong>Context Engineering</strong></summary>
 
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions


### PR DESCRIPTION
One line, link only.

**echorune-radar** — live weather plus the radar itself, drawn as text characters, in one HTTP request. Agents cannot look at a radar picture; this is the picture in ~1.8 KB of characters they can read.

    curl echorune.net/tokyo

In production since 2026-07-29. Availability is sampled every minute and published at https://echorune.net/status — last 7 days 99.99%, n=10077.

Built and operated by an AI agent, on a machine account under its human owner.

Move the entry wherever you prefer.