### PR TITLE
Add community skills: grounded-ai-tutor and project-publisher

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -145,6 +145,54 @@ Instalar mediante [google-gemini/gemini-api-dev](https://agent-skill.co/google-g
 
 ---
 
+## Skills de la Comunidad
+
+<details>
+<summary><strong>Bases de datos vectoriales</strong></summary>
+
+- [qdrant/skills](https://github.com/qdrant/skills) - Búsqueda vectorial, escalado y rendimiento en Qdrant
+</details>
+
+<details>
+<summary><strong>Marketing</strong></summary>
+
+- [BrianRWagner/ai-marketing-skills](https://github.com/BrianRWagner/ai-marketing-skills) - 17 marcos de marketing para outreach y auditorías
+- [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - SEO universal para analizar sitios
+- [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - Más de 20 métodos creativos (SIT, TRIZ, SCAMPER)
+- [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Contrato de estilo para prosa inglesa directa y fuerte
+</details>
+
+<details>
+<summary><strong>Productividad y colaboración</strong></summary>
+
+- [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - Convertir, OCR y redactar PII en documentos
+- [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Convierte docs o código en StudyVaults interactivos
+- [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Memoria jerárquica persistida en el sistema de archivos
+- [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Gestiona issues, proyectos y equipos de Linear
+- [weike-zhang/grounded-ai-tutor](https://github.com/weike-zhang/grounded-ai-tutor) - Tutor de IA que explica el paso que falta, en lenguaje sencillo
+</details>
+
+<details>
+<summary><strong>Desarrollo y pruebas</strong></summary>
+
+- [muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams) - Genera diagramas Excalidraw a mano alzada desde un prompt
+- [coderabbitai/skills](https://github.com/coderabbitai/skills) - Revisión de código y autofix de PRs
+- [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Parte tareas largas (100+ archivos) por descomposición
+- [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Skills de Node.js, Fastify y TypeScript de Matteo Collina
+- [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - Frontend con criterio para evitar UI genérica
+- [weike-zhang/project-publisher](https://github.com/weike-zhang/project-publisher) - Revisa y actualiza los archivos públicos antes del lanzamiento
+</details>
+
+<details>
+<summary><strong>Ingeniería de contexto</strong></summary>
+
+- [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Estrategias de compresión para sesiones largas
+- [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Diseña memoria a corto plazo y basada en grafos
+- [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Memoria en grafo para más contexto y refactors más seguros
+</details>
+
+---
+
 ## Tendencias y Capacidades (2026)
 
 El ecosistema de agentes de IA ha pasado drásticamente de interfaces de chat reactivas a **sistemas autónomos orientados a objetivos** que ejecutan flujos de trabajo de varios pasos de extremo a extremo, un periodo a menudo llamado el "Salto del Agente".

--- a/README.ja.md
+++ b/README.ja.md
@@ -146,6 +146,54 @@ OpenAI カタログからの公式厳選スキル。
 
 ---
 
+## コミュニティスキル
+
+<details>
+<summary><strong>ベクトルデータベース</strong></summary>
+
+- [qdrant/skills](https://github.com/qdrant/skills) - Qdrant のベクトル検索、スケール、性能向けスキル
+</details>
+
+<details>
+<summary><strong>マーケティング</strong></summary>
+
+- [BrianRWagner/ai-marketing-skills](https://github.com/BrianRWagner/ai-marketing-skills) - アウトリーチと監査向けのマーケティング枠組み 17 種
+- [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - サイト分析向けの汎用 SEO スキル
+- [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - SIT / TRIZ / SCAMPER など 20 以上の発想手法
+- [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - 鋭く力強い英語散文のための文体契約
+</details>
+
+<details>
+<summary><strong>生産性とコラボレーション</strong></summary>
+
+- [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - 文書変換、OCR、個人情報の墨消し
+- [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - ドキュメントやコードベースを学習用 StudyVault にする
+- [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - ファイルに残る階層メモリ
+- [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Linear の issue、プロジェクト、チームを管理
+- [weike-zhang/grounded-ai-tutor](https://github.com/weike-zhang/grounded-ai-tutor) - 足りない一歩を平易な言葉で説明する
+</details>
+
+<details>
+<summary><strong>開発とテスト</strong></summary>
+
+- [muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams) - プロンプトから手描き風の Excalidraw 図を生成
+- [coderabbitai/skills](https://github.com/coderabbitai/skills) - コードレビューと PR 自動修正
+- [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - 100 ファイル超の長文脈タスクを分解して進める
+- [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Matteo Collina による Node.js / Fastify / TypeScript スキル
+- [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - 量産 UI を避けるフロントエンド技能
+- [weike-zhang/project-publisher](https://github.com/weike-zhang/project-publisher) - 公開前に対外ファイルを点検して更新する
+</details>
+
+<details>
+<summary><strong>コンテキストエンジニアリング</strong></summary>
+
+- [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - 長時間セッション向けのコンテキスト圧縮
+- [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - 短期記憶とグラフ記憶の設計
+- [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - グラフ記憶でコンテキストを速くし、リファクタを安全にする
+</details>
+
+---
+
 ## トレンドと能力 (2026)
 
 AI エージェントのエコシステムは、反応的なチャットインターフェースから、エンドツーエンドの多段階ワークフローを実行する **自律的で目標駆動型のシステム** へと劇的に変化しました。この時期はしばしば「エージェント・リープ（エージェントの跳躍）」と呼ばれます。

--- a/README.ko.md
+++ b/README.ko.md
@@ -141,6 +141,54 @@ OpenAI 카탈로그의 공식 큐레이션 스킬.
 
 ---
 
+## 커뮤니티 스킬
+
+<details>
+<summary><strong>벡터 데이터베이스</strong></summary>
+
+- [qdrant/skills](https://github.com/qdrant/skills) - Qdrant 벡터 검색, 확장, 성능 스킬
+</details>
+
+<details>
+<summary><strong>마케팅</strong></summary>
+
+- [BrianRWagner/ai-marketing-skills](https://github.com/BrianRWagner/ai-marketing-skills) - 아웃리치와 감사에 쓰는 마케팅 프레임워크 17종
+- [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - 사이트 분석용 범용 SEO 스킬
+- [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - SIT, TRIZ, SCAMPER 등 창의 방법 20가지 이상
+- [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - 강하고 짧은 영어 산문을 위한 문체 계약
+</details>
+
+<details>
+<summary><strong>생산성 및 협업</strong></summary>
+
+- [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - 문서 변환, OCR, 개인정보 삭제
+- [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - 문서나 코드베이스를 인터랙티브 학습고로 바꿈
+- [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - 파일에 남는 계층형 메모리
+- [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Linear 이슈, 프로젝트, 팀 관리
+- [weike-zhang/grounded-ai-tutor](https://github.com/weike-zhang/grounded-ai-tutor) - 빠진 한 단계를 쉬운 말로 설명하는 AI 튜터
+</details>
+
+<details>
+<summary><strong>개발 및 테스트</strong></summary>
+
+- [muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams) - 프롬프트로 손그림풍 Excalidraw 다이어그램 생성
+- [coderabbitai/skills](https://github.com/coderabbitai/skills) - 코드 리뷰와 PR 자동 수정
+- [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - 파일 100개 넘는 긴 작업을 쪼개서 처리
+- [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Matteo Collina의 Node.js, Fastify, TypeScript 스킬
+- [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - 뻔한 UI를 걷어내는 프론트엔드 스킬
+- [weike-zhang/project-publisher](https://github.com/weike-zhang/project-publisher) - 공개 전에 README 등 대외 파일을 점검하고 고침
+</details>
+
+<details>
+<summary><strong>컨텍스트 엔지니어링</strong></summary>
+
+- [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - 긴 세션용 컨텍스트 압축
+- [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - 단기 기억과 그래프 기억 설계
+- [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - 그래프 기억으로 맥락을 빠르게, 리팩터를 안전하게
+</details>
+
+---
+
 ## 트렌드 및 역량 (2026)
 
 AI 에이전트 생태계는 반응형 채팅 인터페이스에서 엔드투엔드 다단계 워크플로우를 실행하는 **자율적이고 목표 중심적인 시스템**으로 급격히 변화했습니다. 이 시기를 흔히 "에이전트 리프(Agent Leap)"라고 부릅니다.

--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [weike-zhang/grounded-ai-tutor](https://github.com/weike-zhang/grounded-ai-tutor) - AI tutor that explains the missing step in plain language
 </details>
 
 <details>
@@ -549,6 +550,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [weike-zhang/project-publisher](https://github.com/weike-zhang/project-publisher) - Review and keep a project's public files current before launch
 </details>
 
 <details>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -151,6 +151,54 @@ npx skills remove [skill-name]     # 卸载技能
 
 ---
 
+## 社区技能
+
+<details>
+<summary><strong>向量数据库</strong></summary>
+
+- [qdrant/skills](https://github.com/qdrant/skills) - Qdrant 向量检索、扩容和性能调优
+</details>
+
+<details>
+<summary><strong>营销</strong></summary>
+
+- [BrianRWagner/ai-marketing-skills](https://github.com/BrianRWagner/ai-marketing-skills) - 17 套获客和审计用的营销框架
+- [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - 通用网站 SEO 分析
+- [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20 多种创意方法（SIT、TRIZ、SCAMPER）
+- [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - 把英文写得硬、短、有力
+</details>
+
+<details>
+<summary><strong>效率与协作</strong></summary>
+
+- [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - 文档转换、OCR、脱敏
+- [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - 把文档或代码库做成可互动的学习库
+- [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - 分层记忆，落盘保存
+- [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - 管理 Linear 的 issue、项目和团队
+- [weike-zhang/grounded-ai-tutor](https://github.com/weike-zhang/grounded-ai-tutor) - 用白话补上你卡住的那一步
+</details>
+
+<details>
+<summary><strong>开发与测试</strong></summary>
+
+- [muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams) - 根据提示生成手绘风 Excalidraw 图
+- [coderabbitai/skills](https://github.com/coderabbitai/skills) - 代码审查和 PR 自动修复
+- [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - 把上百个文件的长任务拆开做
+- [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Matteo Collina 写的 Node.js、Fastify、TypeScript 技能
+- [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - 把套模板的前端界面做回去
+- [weike-zhang/project-publisher](https://github.com/weike-zhang/project-publisher) - 上线前核对并更新对外文件
+</details>
+
+<details>
+<summary><strong>上下文工程</strong></summary>
+
+- [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - 长会话的上下文压缩办法
+- [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - 设计短期记忆和图谱记忆
+- [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - 用图谱记忆加快上下文、降低重构风险
+</details>
+
+---
+
 ## 趋势与能力 (2026)
 
 AI Agent 生态系统已发生巨大转变，从反应式聊天界面演进为执行端到端多步骤工作流的 **自主、目标驱动系统** —— 这一时期通常被称为“Agent 大飞跃”。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -151,6 +151,54 @@ npx skills remove [skill-name]     # 卸載技能
 
 ---
 
+## 社群技能
+
+<details>
+<summary><strong>向量資料庫</strong></summary>
+
+- [qdrant/skills](https://github.com/qdrant/skills) - Qdrant 向量檢索、擴容與效能調校
+</details>
+
+<details>
+<summary><strong>行銷</strong></summary>
+
+- [BrianRWagner/ai-marketing-skills](https://github.com/BrianRWagner/ai-marketing-skills) - 17 套開發客戶與稽核用的行銷框架
+- [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - 通用網站 SEO 分析
+- [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20 多種創意方法（SIT、TRIZ、SCAMPER）
+- [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - 把英文寫得硬、短、有力
+</details>
+
+<details>
+<summary><strong>效率與協作</strong></summary>
+
+- [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - 文件轉換、OCR、個資遮罩
+- [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - 把文件或程式庫做成可互動的學習庫
+- [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - 分層記憶，落盤保存
+- [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - 管理 Linear 的 issue、專案與團隊
+- [weike-zhang/grounded-ai-tutor](https://github.com/weike-zhang/grounded-ai-tutor) - 用白話補上你卡住的那一步
+</details>
+
+<details>
+<summary><strong>開發與測試</strong></summary>
+
+- [muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams) - 依提示產生手繪風 Excalidraw 圖
+- [coderabbitai/skills](https://github.com/coderabbitai/skills) - 程式碼審查與 PR 自動修復
+- [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - 把上百個檔案的長任務拆開做
+- [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Matteo Collina 寫的 Node.js、Fastify、TypeScript 技能
+- [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - 把套模板的前端介面做回去
+- [weike-zhang/project-publisher](https://github.com/weike-zhang/project-publisher) - 上線前核對並更新對外檔案
+</details>
+
+<details>
+<summary><strong>上下文工程</strong></summary>
+
+- [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - 長會話的上下文壓縮辦法
+- [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - 設計短期記憶與圖譜記憶
+- [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - 用圖譜記憶加快上下文、降低重構風險
+</details>
+
+---
+
 ## 趨勢與能力 (2026)
 
 AI Agent 生態系統已發生巨大轉變，從反應式聊天界面演進為執行端到端多步驟工作流程的 **自主、目標驅動系統** —— 這一時期通常被稱為「Agent 大飛躍」。


### PR DESCRIPTION
## What

Add two community skills to the index:

- **[weike-zhang/grounded-ai-tutor](https://github.com/weike-zhang/grounded-ai-tutor)** → *Productivity and Collaboration* — An AI tutor that starts from what the learner knows and explains the exact missing step, without assuming a technical background. Includes before/after evals, a plain-language SKILL.md (97 lines), bilingual docs, and tested install.
- **[weike-zhang/project-publisher](https://github.com/weike-zhang/project-publisher)** → *Development and Testing* — Reviews a project before launch/publish, reports what would stop a new user, and updates only the public files the user approves (README, release notes). SKILL.md under the size limit, with release-leak examples and tested public install.

## Why

Both skills match the [Skill Quality Standards](https://agent-skill.co/#quality-standards): focused scope, real usage examples with before/after comparisons, documented trade-offs, tested against the target agent, and SKILL.md files within the size limit.

## Checks

- Public repositories with working skills ✅
- SKILL.md present in each repo ✅
- Description short (10 words or fewer) ✅
- Author prefix included in the name ✅