### PR TITLE
Add UIZZE anti-ui-slop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
-- [uizze/anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - STOP UI SLOP before it ships: ground product-specific web and iOS UI decisions in 800,000+ real screens and run a hard finish gate
+- [uizze/anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - Free MIT skill for stopping UI slop: use product-specific design contracts, required states, and a hard finish gate; the optional UIZZE workflow adds no-account preview checks plus live search, validation, and audits across 800,000+ real web and iOS screens
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
-- [uizze/anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - Free MIT skill for stopping UI slop: use product-specific design contracts, required states, and a hard finish gate; the optional UIZZE workflow adds no-account preview checks plus live search, validation, and audits across 800,000+ real web and iOS screens
+- [uizze/anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - Free MIT Skill for stopping UI slop with product-specific design contracts, required states, and a hard finish gate; the optional authenticated MCP provides find_ui_references and find_ui_materials over 800,000+ real web and iOS screens.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [uizze/anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - STOP UI SLOP before it ships: ground product-specific web and iOS UI decisions in 800,000+ real screens and run a hard finish gate
 </details>
 
 <details>


### PR DESCRIPTION
## What this adds\n\n- Adds the UIZZE anti-ui-slop skill to Development and Testing.\n- Links directly to the installable SKILL.md directory.\n- Describes the free workflow accurately: STOP UI SLOP, use 800,000+ real web and iOS screens as evidence, and run a hard finish gate.\n\nThis is a focused external skill listing; no generated files or dependencies are added.