### PR TITLE
Add aeonfun/aeon to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [aeonfun/aeon](https://github.com/aeonfun/aeon) - Autonomous agent framework: 70+ cron-scheduled `SKILL.md` skills that run in GitHub Actions, self-healing and fleet-replicating
 </details>
 
 <details>


### PR DESCRIPTION
Adding **[aeonfun/aeon](https://github.com/aeonfun/aeon)** under **Community Skills → Development and Testing** as a whole-repo skills collection (like the other multi-skill repos in that section).

Aeon is an autonomous agent framework: 70+ cron-scheduled `SKILL.md` skills that run entirely in GitHub Actions, self-healing (a health skill files issues, a repair skill fixes them by PR) and fleet-replicating.

- Repo: https://github.com/aeonfun/aeon
- License: MIT · actively maintained
- All skills follow the `SKILL.md` standard.

Single entry appended to the Development and Testing block, formatting matched to the surrounding lines.

Disclosure: I maintain Aeon.