### PR TITLE
Add douyin-agent-kit to Development and Testing skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [liusencomic-cyber/douyin-agent-kit](https://github.com/liusencomic-cyber/douyin-agent-kit) - Douyin video extraction, transcription, and creator distillation for any agent
 </details>
 
 <details>


### PR DESCRIPTION
Add [douyin-agent-kit](https://github.com/liusencomic-cyber/douyin-agent-kit) to Community Skills → Development and Testing.

- Agent-agnostic Douyin (抖音) content extraction & creator distillation skill kit
- GPU transcription (mlx-whisper) + smart visual judgment (local Ollama) + targeted frame extraction + setup wizard
- Follows the SKILL.md standard (2 skills: video-transcribe + favorites-archive), 250 tests passing, CI green
- Works with Hermes / OpenClaw / WorkBuddy / Claude Code / Codex / any local agent