### PR TITLE
feat: add UIZZE anti-ui-slop skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [uizze/uizze](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) - UI quality workflow grounded in 800,000+ real web and iOS screens, design contracts, and a finish gate
 </details>
 
 <details>


### PR DESCRIPTION
## Summary
- add the canonical UIZZE anti-ui-slop Skill to the Development and Testing index
- link the maintained public Skill source
- keep the entry within the directory's short-description format

## Verification
- `git diff --check`
- canonical repository link returns HTTP 200

UIZZE is the project author. The entry describes the free Skill and its `800,000+` real web and iOS screen grounding; the full service remains documented on the canonical repository.
