### PR TITLE
feat: add Zinc universal-checkout skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,9 @@ Official skills for ML workflows.
 - [better-auth/create-auth](https://agent-skill.co/better-auth/skills/create-auth) - Create authentication setup with Better Auth
 - [better-auth/twoFactor](https://agent-skill.co/better-auth/skills/twoFactor) - Two-factor authentication with Better Auth
 
+#### Skills by Zinc
+- [zincio/universal-checkout](https://github.com/zincio/skills/tree/master/skills/universal-checkout) - Discover, buy, track, and return products across 50+ US retailers
+
 <details>
 <summary><strong>Marketing Skills by Corey Haines</strong></summary>
 


### PR DESCRIPTION
## Summary
- Add official **Skills by Zinc** under Official Skill Directories → Business, Productivity & Marketing (alongside Stripe, Resend, and other official product APIs).
- Lists [`zincio/universal-checkout`](https://github.com/zincio/skills/tree/master/skills/universal-checkout), Zinc's official Agent Skill for discovering, buying, tracking, and returning products across 50+ US retailers.

Install: `npx skills add zincio/skills --skill universal-checkout`

Docs: https://www.zinc.com/docs/v2/agent-skills/overview

## Test plan
- [x] Confirm Zinc / zincio / universal-checkout is not already listed elsewhere in the README
- [x] Confirm the new subsection sits with the other official teams in Business, Productivity & Marketing (after Better Auth, before the community `<details>` blocks)
- [x] Confirm the entry matches existing official-team punctuation (no trailing period) and links to the skill folder