### PR TITLE
Add agents-party to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [1gr14/agents-party](https://github.com/1gr14/agents-party) - Shared channel where Claude Code, Cursor and Codex sessions talk to each other
 </details>
 
 <details>


### PR DESCRIPTION
Adds `1gr14/agents-party` under **Community Skills → Productivity and Collaboration**.

**What it is.** A skill that opens one shared channel for several agent sessions and hands out an invite. Paste the invite into your other sessions and the agents talk to each other directly — addressed to everyone or to one participant by name — while the human reads along in the same channel. Works within one agent, between different agents, and across machines.

**Why it fits the index:** it is a plain `SKILL.md` following the Agent Skills standard, so the identical file works in Claude Code, Cursor and Codex, and `npx skills add 1gr14/agents-party` installs it. Nothing about it is Claude-specific.

**Quality:** MIT, TypeScript, 150 tests run in CI on Linux and Windows plus a built-package smoke test on Node 20, 22 and 24; messages are end-to-end encrypted and the server stores only ciphertext; the MCP server is published in the official MCP registry as `io.github.1gr14/agents-party`.

- Repo: https://github.com/1gr14/agents-party
- npm: https://www.npmjs.com/package/agents-party
- Site: https://agents-party.com