### PR TITLE
feat: add hypergrok-trading-desk

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ That's it. No installation. No configuration. No coding required.
   - [Productivity and Collaboration](#productivity-and-collaboration)
   - [Development and Testing](#development-and-testing)
   - [Context Engineering](#context-engineering)
+  - [Finance and Trading](#finance-and-trading)
 - [Skill Quality Standards](#skill-quality-standards)
 - [Using Skills](#using-skills)
 - [Creating Skills](#creating-skills)
@@ -557,6 +558,12 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
+</details>
+
+<details>
+<summary><strong>Finance and Trading</strong></summary>
+
+- [galleonlabs/hypergrok-trading-desk](https://github.com/galleonlabs/hypergrok-trading-desk) - 7-role Hyperliquid trading desk: research, risk, ticketed execution, review
 </details>
 
 ---


### PR DESCRIPTION
## Summary
Adds [galleonlabs/hypergrok-trading-desk](https://github.com/galleonlabs/hypergrok-trading-desk) under a new Community Skills group: **Finance and Trading**, and lists that group in the table of contents.

HyperGrok is an MIT Agent Plugin: seven role prompts plus sixteen `SKILL.md` skills for a Hyperliquid trading desk (research, risk, ticketed execution, review). You approve every trade by ticket id.

Install: `npx skills add galleonlabs/hypergrok-trading-desk`