### PR TITLE
Add sell-unused-tokens skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
-- [ADWilkinson/sell-unused-tokens](https://github.com/ADWilkinson/tokenstocash/tree/main/skills/sell-unused-tokens) - List leftover LLM API credits on tokensto.cash and cash out USDC (Revolut, Monzo, Chime, Zelle)
+- [galleonlabs/sell-unused-tokens](https://github.com/galleonlabs/sell-unused-tokens) - List leftover LLM API credits on tokensto.cash and cash out USDC (Revolut, Monzo, Chime, Zelle)
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
-- [galleonlabs/sell-unused-tokens](https://github.com/galleonlabs/sell-unused-tokens) - List leftover LLM API credits on tokensto.cash and cash out USDC (Revolut, Monzo, Chime, Zelle)
+- [galleonlabs/sell-unused-tokens](https://github.com/galleonlabs/sell-unused-tokens) - List leftover LLM API credits on tokensto.cash and cash out USDC (Revolut, Monzo, Chime, Zelle direct; Venmo, Cash App, Wise, PayPal after a one-time USDCtoFiat Verify registration)
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [ADWilkinson/sell-unused-tokens](https://github.com/ADWilkinson/tokenstocash/tree/main/skills/sell-unused-tokens) - List leftover LLM API credits on tokensto.cash and cash out USDC (Revolut, Monzo, Chime, Zelle)
 </details>
 
 <details>


### PR DESCRIPTION
Adds a Community Skills link for `sell-unused-tokens` under Development and Testing.

The skill lists leftover LLM API credits on https://tokensto.cash and cashes out USDC. Live rails today: Revolut, Monzo, Chime, Zelle only. Venmo, Cash App, Wise, and PayPal are coming soon.

Skill folder: https://github.com/ADWilkinson/tokenstocash/tree/main/skills/sell-unused-tokens