### PR TITLE
Add repo-cover under Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,6 +552,12 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 </details>
 
 <details>
+<summary><strong>Design and Visuals</strong></summary>
+
+- [sjh9714/repo-cover](https://github.com/sjh9714/repo-cover) - Design GitHub social-preview cards (og:image) as one self-contained HTML file, four moods, CJK-first, deterministic checks
+</details>
+
+<details>
 <summary><strong>Context Engineering</strong></summary>
 
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions


### PR DESCRIPTION
Adds [repo-cover](https://github.com/sjh9714/repo-cover) in a new Design and Visuals group under Community Skills, since the existing groups had no home for design-output skills. Happy to move it into an existing group if you prefer.

Against the Skill Quality Standards. Clear instructions with one mood reference plus one example per run. Focused scope, a single 1280x640 social-preview card. Working examples, eight cards checked into the repo and shown live at https://sjh9714.github.io/repo-cover/ with view-source. Documented trade-offs, a when-not-to-use section and star counts off by default because they go stale. SKILL.md is about 100 lines, well under 500. Tested, two independent agents ran the installed skill cold and both cards passed the bundled deterministic checker (canvas, self-containment, WCAG contrast, CJK line-breaking) on the first try.