### PR TITLE
feat: add agent eval tracer skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [Cyberpradeep/Agent-Skills](https://github.com/Cyberpradeep/Agent-Skills) - Isolated multi-agent evaluation, consistency analysis, memory retention testing, and masking-first reports
 </details>
 
 <details>


### PR DESCRIPTION
## Summary
- add Agent Eval Tracer to the Development and Testing skill index
- link to the standalone skill repository

Agent Eval Tracer supports isolated multi-agent evaluation, consistency analysis, memory retention testing, and masking-first reporting.

## Validation
- `git diff --check` passes
- standalone skill repository contains `SKILL.md`, references, scripts, and demo artifacts