### PR TITLE
Add pptx-to-html-trace to Productivity and Collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [JunoChenZt/pptx-to-html-trace](https://github.com/JunoChenZt/pptx-to-html-trace) - Rebuild PowerPoint or PDF slides as HTML with overlay and difference verification
 </details>
 
 <details>


### PR DESCRIPTION
Adds one entry to **Productivity and Collaboration**.

**[pptx-to-html-trace](https://github.com/JunoChenZt/pptx-to-html-trace)** — rebuilds a PowerPoint or PDF slide as HTML that matches the original, and ships the original render with the page as a comparison layer so the match can actually be checked: HTML only · Reference only · Overlay · Difference. In difference mode matched pixels go black, so only the errors glow.

The premise is that slide replication fails for two reasons, neither of them model intelligence. There is no ruler — coordinates get estimated from pixels and fonts hallucinated — so the skill reads exact positions, sizes, letter-spacing and colours straight out of the `.pptx` XML, and pulls the original image assets rather than redrawing them. And there are no eyes — CSS gets written and never rendered — so every result is judged against a rendered comparison instead of by re-reading the CSS.

Against the quality standards in CONTRIBUTING:

- `SKILL.md` is 312 lines, under the 500-line guidance
- The bundled extractor is pure Python standard library: no dependencies and no network, so it works in chat sandboxes where `pip install` fails
- Trade-offs are documented rather than glossed: `--verify` states plainly that it covers canvas ratio, solid fills, uncovered ink and text overflow, and that typography and effects are **not** covered
- Test fixtures and an eval README are included in the repo
- Documentation in English and Simplified Chinese; MIT licensed

Happy to adjust the wording or move it to a different category if Development and Testing is a better fit.