### PR TITLE
Add MM-sheng/use-404-directory skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [MM-sheng/use-404-directory](https://github.com/MM-sheng/404-directory/tree/main/skills/use-404-directory) - Search official docs, verify deployments, and discover trusted MCP tools
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

- add the `use-404-directory` community skill under Development and Testing
- link directly to the public `SKILL.md` directory
- keep the description concise and focused on its three real workflows

## Validation

- public skill directory returns HTTP 200
- upstream Skill passes the Agent Skills validator
- upstream service exposes 12 read-only MCP tools without an account or API key
- `website/` production build passes locally

The Skill teaches compatible Agents to search current official OpenAI/Microsoft/AWS/Cloudflare documentation, verify public deployments with evidence, and discover trusted read-only MCP tools. It requires a useful non-error call and explicitly rejects traffic-only calls.