### PR TITLE
Add Copycat Skills to Community Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,6 +528,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 
 - [BrianRWagner/ai-marketing-skills](https://github.com/BrianRWagner/ai-marketing-skills) - 17 marketing frameworks for outreach and audits
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
+- [canhta/copycat-skills](https://github.com/canhta/copycat-skills) - Research mobile app competitors and reviews before evidence-backed build, validate, pivot, or no-go decisions
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
 </details>


### PR DESCRIPTION
## Summary

Add [canhta/copycat-skills](https://github.com/canhta/copycat-skills) to Community Skills → Marketing.

Copycat is a portable Agent Skills pack for mobile app product research. It combines cross-store competitor discovery, bounded review mining, market evidence, separate Blue/Red evaluation, and a final BUILD, VALIDATE, PIVOT, or NO_GO decision.

## Quality checks

- Public MIT-licensed repository with working `SKILL.md` files
- Main orchestrator `SKILL.md` is 54 lines, below the list's 500-line guidance
- Includes examples, documented trade-offs, validation scripts, and tests
- Supports Codex and Claude Code
- Confirmed the link resolves and the README change passes `git diff --check`