### PR TITLE
Add GPT Image 2 multilingual text design skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
+- [sjh9714/gpt-image-2-text-design](https://github.com/sjh9714/gpt-image-2-text-design) - OCR-verified EN/KO/JA posters, infographics, and product cards from generated visual masters
 </details>
 
 <details>


### PR DESCRIPTION
## What this adds

Adds `sjh9714/gpt-image-2-text-design` to Community Skills → Marketing. The skill creates text-heavy posters, infographics, and product cards with generated visual masters, deterministic EN/KO/JA copy overlays, and Tesseract OCR receipts.

## Quality evidence

- self-contained `SKILL.md` package with a safe project scaffolder
- 8 visual masters and 24 OCR-passed locale outputs
- behavioral and schema tests plus Ubuntu CI with `eng`, `kor`, and `jpn` Tesseract packs
- public gallery and downloadable receipts

## Verification

- `cd website && npm ci`
- `cd website && npm run build`

The website build completed successfully with Next.js 16.2.2.