### PR TITLE
Add skill: curyous/clear-agent-fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [curyous/clear-agent-fetch](https://github.com/curyous/clear-agent-fetch) - Fetch a public URL as markdown via x402
 </details>
 
 <details>


### PR DESCRIPTION
Adds [Clear](https://github.com/curyous/clear-agent-fetch) to Community Skills / Development and Testing.

Clear is a live x402 skill: POST `/v1/fetch` returns a public URL as markdown. $0.005 USDC on Base via PayAI. Fail is free. SKILL.md at repo root.

Live: https://clear-agent-fetch.fly.dev
