### PR TITLE
Add skill: zltstl888/apex-tool-evaluator

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [zltstl888/apex-tool-evaluator](https://github.com/zltstl888/apex-tool-evaluator) - Evidence-led AI tool adoption decisions and safe tests
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

- Add APEX Tool Evaluator under Community Skills → Development and Testing.
- Link to the public Agent Skill repository and describe its evidence-led adoption decision workflow.

## Quality checks

- Public repository with `SKILL.md`, README, compact examples, eval fixtures, tests, CI, license, provenance, and security policy.
- Latest tagged release: `v0.1.1`.
- Upstream website verification: `npm run build` passed locally.