### PR TITLE
Add Instructree to development and testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,6 +546,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 
 - [muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams) - Generate hand-drawn Excalidraw diagrams from prompt
 - [coderabbitai/skills](https://github.com/coderabbitai/skills) - Code review and PR autofix workflows
+- [kotobuki09/instructree](https://github.com/kotobuki09/instructree) - Map and lint the instructions AI coding agents may apply before they edit code
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop


### PR DESCRIPTION
Adds Instructree to the Development and Testing section. The repository provides a portable SKILL.md plus a zero-dependency CLI and GitHub Action for mapping and linting AGENTS.md, CLAUDE.md, Copilot instructions, and agent skills. Verification: the linked repository returns 200 and the website builds successfully with npm run build.