### PR TITLE
Add falsify: scientific thinking protocol skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
+- **[263311487-ux/falsify](https://github.com/263311487-ux/falsify)** - Scientific thinking protocol for AI agents: falsify before you believe (28 evals, npm: falsify-skill, works with 20+ agents)
 </details>
 
 ---


### PR DESCRIPTION
## Add [falsify](https://github.com/263311487-ux/falsify) to Community Skills → Context Engineering

**falsify** is the scientific thinking protocol for AI agents — axioms → hypothesis → adversarial test → evidence → calibrated verdict. It stops agents from giving confident answers they cannot falsify.

- Single Markdown skill (SKILL.md standard), works with 20+ agents (Codex, Claude Code, Cursor, Gemini CLI, Copilot, ...)
- Bundled: bias catalog + mental models (Galef/Snowden/Boyd/Kahneman) + thinking ledger template
- 28 evaluation cases, 4/4 external dogfood cross-validation passed
- Also on npm: `npx falsify-skill`