### PR TITLE
Add writing-skills: 15 writing-style skills (8 frameworks + 7 character voices)

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,9 @@ Official skills for ML workflows.
 #### Skills by Typefully
 - [typefully/typefully](https://agent-skill.co/typefully/skills/typefully) - Create, schedule, and publish social media content
 
+#### Skills by Surendran B
+- [surendranb/writing-skills](https://github.com/surendranb/writing-skills) - 15 writing-style skills: 8 measurable frameworks (plain language, ASD-STE100, AP journalism, GOV.UK, business BLUF) and 7 character voices, each with a verify checklist
+
 #### Skills by Composio
 - [composiohq/composio](https://agent-skill.co/composiohq/skills/composio) - Connect AI agents to 1000+ external apps with managed authentication
 


### PR DESCRIPTION
Adds [surendranb/writing-skills](https://github.com/surendranb/writing-skills) — 15 writing-style skills as spec-conformant SKILL.md files:

- **8 measurable frameworks**: plain-language (Plain Writing Act), asd-ste100 (Simplified Technical English), journalism-ap (AP Stylebook), gov-uk-style, google-dev-docs, business-writing (BLUF), corporate-communication, scott-adams
- **7 character voices**: ted-lasso, jack-sparrow, shrek, yoda, winnie-the-pooh, paddington, bob-ross

Every skill follows the agentskills.io spec (name + description frontmatter, folder-name match), enforces mechanics an agent can verify (word caps, ban lists, ratios), and ends with a Verify checklist. CI validates the contract on every commit. MIT licensed, works in Claude Code, Codex, opencode, Cursor, Gemini CLI.