### PR TITLE
Add Screened - dual-screener title/abstract skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [andreaslofberg/screened](https://github.com/andreaslofberg/screened) - Dual-screener title/abstract worksheet for systematic reviews.
 </details>
 
 <details>


### PR DESCRIPTION
Screened is an agent skill that produces a dual-screener title/abstract worksheet for systematic reviews, so two reviewers can screen records independently and reconcile conflicts.

- Section: Community Skills > Productivity and Collaboration (added at the bottom of that list)
- SKILL.md: https://github.com/andreaslofberg/screened/blob/main/skills/screened/SKILL.md
- License: MIT
- Compatible with Cursor and other agents that load SKILL.md
- Disclosure: I own the linked repository.