### PR TITLE
Add NERV-UI agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [mdrbx/nerv-ui](https://github.com/mdrbx/nerv-ui/tree/master/skills/nerv-ui) - Typed React command-center components, live examples, and a portable Agent Skills-compatible skill
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adds the NERV-UI portable coding-agent skill to the Community Skills → Development and Testing section.

- Skill: https://github.com/mdrbx/nerv-ui/tree/master/skills/nerv-ui
- Project: https://github.com/mdrbx/nerv-ui
- Live examples: https://mdrbx.github.io/nerv-ui/

## Validation

- Confirmed the public `SKILL.md` is available on the default branch.
- Ran `npm ci` and `npm run build` in `website/` successfully.