### PR TITLE
Add SandBase CLI Agent Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,9 @@ Official skills for ML workflows.
 #### Skills by MiniMax
 - [MiniMax-AI/frontend-dev](https://agent-skill.co/MiniMax-AI/skills/frontend-dev) - Frontend with animations and AI media via MiniMax
 - [MiniMax-AI/minimax-pdf](https://agent-skill.co/MiniMax-AI/skills/minimax-pdf) - Generate, fill, and reformat PDFs
+
+#### Skills by SandBase
+- [sandbaseai/cli](https://github.com/sandbaseai/cli/tree/main/skills/sandbase) - Official SandBase skill and MCP bridge for connecting coding agents to 2,000+ AI models and APIs
 ### Cloud & Infrastructure
 
 #### Skills by Cloudflare


### PR DESCRIPTION
Adds the official SandBase skill to the AI Platforms & Models section.

- Skill source: https://github.com/sandbaseai/cli/tree/main/skills/sandbase
- The linked SKILL.md documents the local MCP bridge and supported client workflow.
- Description is concise and based on the project documentation.
- Disclosure: I am affiliated with SandBase and used AI assistance to prepare this entry.