### PR TITLE
Add falsify — scientific thinking protocol skill (Community Skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [263311487-ux/falsify](https://github.com/263311487-ux/falsify) - The scientific thinking protocol for AI agents: falsification-first, no verdict without a falsifiable hypothesis; 28-case eval suite (dual-model 26/28), live browser checker
 </details>
 
 <details>


### PR DESCRIPTION
Adds [falsify](https://github.com/263311487-ux/falsify) to **Community Skills → Productivity and Collaboration** — the scientific thinking protocol for AI agents.

**What it is:** a 5-stage falsification-first protocol (axioms → hypothesis → adversarial test → evidence → calibrated verdict). *No verdict without a falsifiable hypothesis* — stops agents from giving confident answers they cannot falsify, on architecture choices, bug theories, data claims, and security judgments.

**Why it belongs:**
- **Provable**: 28-case runnable eval suite, cross-model validated on two external DeepSeek models both directions (**26/28, avg 15.3–16.4/18**); real-community dogfood 4/4 on GitHub/Stack Overflow questions
- **Live checker**: https://263311487-ux.github.io/falsify/ — 8 one-click examples + a 5-question falsifiability quiz, shareable via `?q=`, no install
- **Adopted**: already merged into sickn33/agentic-awesome-skills (AAS catalog), indexed on skills.sh (Vercel), npm `falsify-skill` 270+/wk
- **Local & private**: pure Markdown + local JS, zero network calls; SKILL.md under 500 lines

Install: `npx skills add 263311487-ux/falsify` · `npx falsify-skill`
