### PR TITLE
Add massimodeluisa/nerdfonts-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [muthuishere/hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams) - Generate hand-drawn Excalidraw diagrams from prompt
 - [coderabbitai/skills](https://github.com/coderabbitai/skills) - Code review and PR autofix workflows
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
+- [massimodeluisa/nerdfonts-skill](https://github.com/massimodeluisa/nerdfonts-skill) - Nerd Fonts glyphs for any icon: fonts, codepoints, terminal setup
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
 </details>


### PR DESCRIPTION
Adds **nerdfonts-skill** next to my recursive-decomposition-skill entry in Development and Testing.

It makes agents use Nerd Fonts glyphs for any icon (CLI output, TUIs, prompts, statuslines, editor and terminal configs, web), bundles a snapshot of the 10,995 glyph names and codepoints so nothing is guessed, covers install per OS (brew, scoop, pacman, release assets) and patched family names, and has a review mode for existing configs. MIT, Agent Skills format, CI-validated, `npx skills add massimodeluisa/nerdfonts-skill`.

https://github.com/massimodeluisa/nerdfonts-skill
