### PR TITLE
Add skill: truelove-dreamer/plugin-forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [truelove-dreamer/plugin-forge](https://github.com/truelove-dreamer/plugin-forge) - Five-phase gated workflow (intake, scaffold, author, validate, publish) for building and shipping skills/plugins across hosts; includes a structural validator and starter templates
 </details>
 
 <details>


### PR DESCRIPTION
## What

Adds [plugin-forge](https://github.com/truelove-dreamer/plugin-forge) to **Community Skills → Development and Testing**.

plugin-forge is a meta-skill (follows the SKILL.md standard) that standardizes how agents build and ship new skills/plugins: a five-phase gated pipeline — intake → scaffold → author → validate → publish (GitHub repo + release) → post-release install verification.

- Host-neutral: skills follow the open Agent Skills standard; runs in Claude Code, ZCode, and other compatible agents
- Bundled structural validator (`validate.py`), authoring guide, validation checklist, publish guide, and starter templates
- MIT licensed, release [v0.2.0](https://github.com/truelove-dreamer/plugin-forge/releases/tag/v0.2.0)
- Entry follows the existing `- [owner/repo](url) - description` format, inserted in the Development and Testing section
