### PR TITLE
Add persona-os (53 product management skills) to Productivity and Collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [Sidsaladi9/persona-os](https://github.com/Sidsaladi9/persona-os) - 53 product management skills spanning discovery, strategy, specs, and GTM
 </details>
 
 <details>


### PR DESCRIPTION
Adding **persona-os** to *Community Skills → Productivity and Collaboration*.

**Repo:** https://github.com/Sidsaladi9/persona-os · MIT · public

An installable OS for product managers. 53 skills following the `SKILL.md` standard, covering discovery, user research, strategy, planning, specs, metrics, go-to-market and team communication.

Relevant to this index specifically:

- **Follows the SKILL.md standard** — each skill is `skills/<name>/SKILL.md` with frontmatter `description`
- **Multi-agent** — ships prebuilt bundles for Claude Code, Claude Cowork, Codex, Cursor and Gemini CLI from one source
- **Quality-gated** — every skill is scored out of 100 by a scorer in CI; the repo does not ship a skill below the bar
- **Persistent memory** — a `memory/` folder that carries product, team and decision context across sessions, plus a loop that proposes new skills from repeated work

Checked before opening:

- [x] Public repo, MIT licensed, links working
- [x] Repo is 73 days old with active development
- [x] Format matches surrounding entries (one line, factual description, no promotional language)
- [x] Read CONTRIBUTING.md and the quality standards

Happy to move it to a different section or shorten the description if you'd prefer.