### PR TITLE
Add advibly/skills to Community Skills (Marketing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
+- [advibly/skills](https://github.com/advibly/skills) - Ad-creative skills producing finished UGC, explainer, claymation, and collage video ads via the Advibly MCP
 </details>
 
 <details>


### PR DESCRIPTION
Adds [advibly/skills](https://github.com/advibly/skills) to **Community Skills → Marketing**.

A collection of eight ad-creative skills following the SKILL.md standard (each folder is one self-contained skill with frontmatter and references). They drive the [Advibly](https://advibly.com) MCP server to produce finished ad output rather than briefs: UGC video ads, explainer videos in ten visual styles, claymation, Pixar-style 3D, stick-figure comics, collage motion, Vox-style paper collage, and restyling of existing videos.

- Install: `npx skills add advibly/skills -s ugc-ads` (works with Claude Code and other Agent Skills-compatible clients)
- Prerequisite: a connected Advibly account (remote MCP, OAuth) — the skills orchestrate its generation tools
- README-only change, appended to the end of the Marketing block in the existing entry format

**Disclosure:** I'm affiliated with Advibly (co-founder); this PR was prepared with AI assistance.