### PR TITLE
Add pronounce-word developer pronunciation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [anzy-renlab-ai/pronounce-word](https://github.com/anzy-renlab-ai/pronounce/tree/main/skills/pronounce-word) - Play sourced developer-jargon pronunciations with local TTS, IPA, and contested alternatives
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adds `anzy-renlab-ai/pronounce-word` to the Community Skills productivity section.

The skill answers developer-jargon pronunciation requests with actual local audio, IPA, a plain-English respelling, source citations where available, and alternate readings for contested names such as GIF, SQL, and kubectl. It follows the `SKILL.md` convention and is published through the native GitHub Agent Skill flow at v2.28.1.

## Quality checks

- `gh skill publish --dry-run` passes with no skill validation warnings.
- The source project has 41 Node tests, 104 Python tests, dictionary lint, CLI smoke tests, and a successful hosted GitHub Action run.
- `git diff --check` passes for this one-line index change.
- I attempted the requested `website` build twice; both `npm ci` runs stopped before compilation with npm registry `ECONNRESET`. No package or generated files changed.