### PR TITLE
Add personal-understanding (evidence-chain personal memory skill)

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [PSPDFKit-labs/nutrient-agent-skill](https://github.com/PSPDFKit-labs/nutrient-agent-skill) - Document processing: convert, OCR, and redact PII
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
+- [caix84476-netizen/personal-understanding](https://github.com/caix84476-netizen/personal-understanding) - Verbatim-first, evidence-chain personal memory: captures your exact words immutably, then derives events, entities, and causal hypotheses — every fact traceable to its source. Local-first, stdlib-only.
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
 </details>
 


### PR DESCRIPTION
## What

Adds **[caix84476-netizen/personal-understanding](https://github.com/caix84476-netizen/personal-understanding)** — an evidence-chain personal memory skill for AI agents.

Verbatim-first: it saves the user's exact words immutably (SHA-256 hashed, timestamped, session-tagged) **before** anything else, then derives events, entities, context cards, and candidate causal hypotheses from that evidence. Every derived fact links back to its verbatim source — no more un-auditable paraphrased memories.

- 100% local-first, one folder, Python **stdlib only** (no pip installs)
- Works with Claude Code, Codex, VS Code / Cursor / Windsurf / Cline / Trae, ZCode, and any MCP client
- Includes hard derivation-closure gates and a local audit dashboard
- English (`SKILL.md`) + 中文 (`SKILL.zh-CN.md`)
- MIT licensed; also published on [PyPI](https://pypi.org/project/personal-understanding/)

The repo is actively maintained (v2.2.0, CI-tested, ~every failure mode documented in the CHANGELOG).
