### PR TITLE
feat: add Luca-Blight/think-for-yourself agency skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [Luca-Blight/think-for-yourself](https://github.com/Luca-Blight/think-for-yourself) - Agency skill: pick next unblocked action and start
 </details>
 
 <details>


### PR DESCRIPTION
## Summary
- Adds [Luca-Blight/think-for-yourself](https://github.com/Luca-Blight/think-for-yourself) under Community Skills → Productivity and Collaboration.
- Generic agency skill: when idle or waiting on a ping, pick the next unblocked action in your lane and start. Not product-locked.
- Install: `npx skills add Luca-Blight/think-for-yourself`
- Includes scenario eval suite under `evals/`.

## Checklist
- [x] Public repo with SKILL.md
- [x] Short description
- [x] Link verified