### PR TITLE
docs: add flaqai backlink skill to Community Skills > Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
+- [flaqai/submit-product-directories-v2-quality](https://github.com/flaqai/backlink_skills/tree/main/submit-product-directories-v2-quality) - Evidence-first product-directory qualification with authorization and verification gates
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adds the `submit-product-directories-v2-quality` skill from [flaqai/backlink_skills](https://github.com/flaqai/backlink_skills/tree/main/submit-product-directories-v2-quality) to **Community Skills → Marketing**.

The skill provides an evidence-first workflow for qualifying and submitting truthful product listings, with authorization, verification, privacy, and audit gates. It explicitly excludes bulk spam, ranking manipulation, paid link acquisition, and automated low-quality directory submissions.

- README-only change; appended to the existing Marketing community list.
- The source repository is public and MIT-licensed.
- The source repository is maintained by the submitting organization; this is a first-party/self-submission.
- The source skill's `SKILL.md` is 106 lines and includes operational guidance, examples, references, and an audit script/test suite.

## Verification

- `git diff --check`
- Source skill tests: `python3 -m unittest discover -s submit-product-directories-v2-quality/tests` (22 tests passed in the source repository)
- `npm run build` was not run successfully because the cloned repository's `website/` dependencies are not installed (`next: command not found`); this PR changes only `README.md`.
