### PR TITLE
Add BulkPublish social media content skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
+- [azeemkafridi/bulkpublish-api social media content skills](https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills) - Plan, adapt, review, schedule, and publish social content through BulkPublish
 </details>
 
 <details>


### PR DESCRIPTION
Adds the public BulkPublish Social Media Content Skills collection to the Marketing section. The collection contains 24 documented skills for AI agents to plan, adapt, review, schedule, and publish social media content through BulkPublish.