### PR TITLE
Add Laravel development workflow skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [Junaid-PK/laravel-development-workflow](https://github.com/Junaid-PK/laravel-development-workflow) - Build Laravel features and root-cause fixes with risk-based verification
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

- add `Junaid-PK/laravel-development-workflow` to Community Skills → Development and Testing
- describe its focused Laravel feature, root-cause bug-fix, and verification workflow

The linked public repository includes a standard `SKILL.md`, usage examples, documented trade-offs, a validated v1.0.0 release, and an MIT license.

## Validation

- `git diff --check`
- `cd website && npm ci && npm run build`