### PR TITLE
Add uxgen checkout-upsell skill (Business, Productivity & Marketing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,9 @@ Official skills for ML workflows.
 #### Skills by Courier
 - [trycourier/courier-skills](https://github.com/trycourier/courier-skills) - Multi-channel notifications via email, SMS, push, and chat
 
+#### Skills by uxgen
+- [kinerette/claude-code-checkout-upsell](https://github.com/kinerette/claude-code-checkout-upsell) - Decides which upsell goes where in a store (order bump in the checkout, one-click upsell after payment, one cross-sell and a free-shipping bar in the cart) from the merchant's product, with the EU, UK and US consumer-law constraints attached
+
 #### Skills by Typefully
 - [typefully/typefully](https://agent-skill.co/typefully/skills/typefully) - Create, schedule, and publish social media content
 


### PR DESCRIPTION
Adds a `#### Skills by uxgen` block with one skill under **Business, Productivity & Marketing**, after Courier.

**Skill:** `checkout-upsell` — https://github.com/kinerette/claude-code-checkout-upsell

**What it does:** decides which basket-growing mechanic belongs on which surface — quantity breaks on the product page, free-shipping bar and one cross-sell in the cart, one order bump in the checkout, one-click upsell after payment — from the merchant's product (honest complement? consumable or durable? basket size? does anything ship?), and builds it with the consumer-law constraints attached (no pre-ticked add-on: art. 22 of 2011/83/EU makes it refundable; prior price = 30-day lowest; "free" means free; the pay button states the amount).

- `SKILL.md` follows the standard: frontmatter, when to use, instructions, on-demand `references/` (placement table, order bump, post-purchase, cart cross-sell, rules with linked primary texts), worked before/after examples.
- Under 200 lines; MIT; no dependencies; verified to exist and install with `npx skills add kinerette/claude-code-checkout-upsell`.