### PR TITLE
Add skill: nurulislamkhan/rankthread-agent-skill-audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [nurulislamkhan/rankthread-agent-skill-audit](https://github.com/nurulislamkhan/rankthread-agent-skill-audit) - Audit Agent Skills for specification errors, broken references, and release risks
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -549,7 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
-- [nurulislamkhan/rankthread-agent-skill-audit](https://github.com/nurulislamkhan/rankthread-agent-skill-audit) - Audit Agent Skills for specification errors, broken references, and release risks
+- [nurulislamkhan/rankthread-agent-skill-audit](https://github.com/nurulislamkhan/rankthread-agent-skill-audit) - Audit Agent Skills for specification errors, broken references, and risks
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

Adds `rankthread-agent-skill-audit` to Community Skills > Development and Testing.

The skill is a focused, read-only-by-default release audit for Agent Skills. It checks specification metadata, folder naming, broken local references, portability issues, wildcard tool permissions, and unfinished placeholders. The repository includes a dependency-free Node.js CLI, a manual safety rubric, six passing tests, and a browser-only checker.

## Verification

- `npm test` in the skill repository: 6/6 passed
- Skill self-audit: ready, 0 errors, 0 warnings
- Codex skill validator: valid
- This index's `website`: `npm ci` and `npm run build` passed
- Install tested with `npx skills add nurulislamkhan/rankthread-agent-skill-audit --skill rankthread-agent-skill-audit`