### PR TITLE
feat: add aig-agent-redteam skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [Tencent/aig-agent-redteam](https://github.com/Tencent/AI-Infra-Guard/tree/main/skills/aig-agent-redteam) - One-command Agent red-team security assessment
 </details>
 
 <details>


### PR DESCRIPTION
Adding a real, installable Agent Skill to Community Skills → Development and Testing.

**[Tencent/aig-agent-redteam](https://github.com/Tencent/AI-Infra-Guard/tree/main/skills/aig-agent-redteam)** - One-command Agent red-team security assessment

Installs into an Agent client (Claude Code, CodeBuddy, Cursor, etc.) and lets the agent attack itself: prompt injection, indirect injection, tool abuse, data leakage, privilege escalation, SSRF, supply-chain risk, and infra exposure. Uses first-principles red-team reasoning (model capabilities/trust boundaries → attack hypotheses → minimal-harm verification → evidence-backed report) rather than a static payload library. Backed by Tencent Zhuque Lab's AI-Infra-Guard (Apache-2.0, github.com/Tencent/AI-Infra-Guard), an established open-source AI red-teaming platform already integrated into OpenClaw's ClawHub scanning pipeline. Ships with SKILL.md, README.md, and a zh-CN translation.

Happy to move it to a different section or adjust wording to match your conventions.