### PR TITLE
Add kavel-image skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 <summary><strong>Vector Databases</strong></summary>
 
 - [qdrant/skills](https://github.com/qdrant/skills) - Agent skills for Qdrant vector search, scaling, and performance
+- [kavel-image](https://github.com/hanshs474/kavel-image-skill) - Generate images and edit photos from a prompt with no API key and no account, through Kavel's anonymous endpoint — text-to-image plus face-preserving edits (hairstyle, outfit, expression). *By [@hanshs474](https://github.com/hanshs474)*
 </details>
 
 <details>


### PR DESCRIPTION
Adds [kavel-image](https://github.com/hanshs474/kavel-image-skill) under **Community Skills**.

Generates images and edits photos with **no API key and no account** — most image skills need a provider key before they do anything. It calls an anonymous endpoint, so a fresh install produces a picture on the first call (15 free credits, 5 per text-to-image; output is 1K and watermarked, which the skill states plainly).

The SKILL.md documents the real limits rather than the happy path: which model can and cannot take an image input, that the anonymous wallet cannot cover video at any setting, and the three failure modes that actually occur (content-filter refusal, queue waits, per-IP daily ceiling).

MIT licensed.