### PR TITLE
docs: add Skill Security Audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,6 +392,9 @@ Comprehensive SaaS marketing stack skills by [Corey Haines](https://github.com/c
 
 ### Security & Web Intelligence
 
+#### Community Skills
+- [sandbaseai/skill-security-audit](https://github.com/sandbaseai/awesome-workbuddy/tree/main/skills/skill-security-audit) - Audit third-party Skills, MCP servers, and extensions before installation by mapping permissions, credentials, data flows, dependencies, network access, and destructive actions
+
 #### Skills by Trail of Bits
 - [trailofbits/audit-context-building](https://agent-skill.co/trailofbits/skills/audit-context-building) - Deep architectural context via granular code analysis
 - [trailofbits/building-secure-contracts](https://agent-skill.co/trailofbits/skills/building-secure-contracts) - Smart contract security toolkit for 6 blockchains


### PR DESCRIPTION
## What it adds

Adds the portable **Skill Security Audit** workflow to Security & Web Intelligence. It helps users inspect third-party Skills, MCP servers, and extensions before installation.

## Problem solved

Agent extensions can hide broad filesystem access, credential handling, network egress, dependency install hooks, or destructive actions behind benign instructions. This Skill produces an evidence-backed pre-installation review and stays read-only by default.

## Verification

- Public `SKILL.md` with concrete workflow and examples
- Dedicated permission/data-flow and dependency/provenance reference checklists
- Structural validation passes in the source repository
- `website`: `npm ci && npm run build` passes

Related: #467