### PR TITLE
docs: add WorkBuddy Skill Atlas discovery option

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -90,6 +90,10 @@ Se recomienda utilizar el **[SkillsMP Marketplace](https://skillsmp.com)**, que 
 
 También puedes usar **[skills.sh](https://skills.sh)** —— el leaderboard de Vercel —— para ver intuitivamente los repositorios de Skills más populares y las estadísticas de uso de Skills individuales.
 
+### WorkBuddy Skill Atlas
+
+Para usuarios de WorkBuddy, **[WorkBuddy Skill Atlas](https://sandbaseai.github.io/workbuddy-skill/)** indexa más de 10.000 rutas públicas `SKILL.md` con procedencia inmutable de GitHub, detección de duplicados, puntuación de compatibilidad y señales conservadoras de revisión estática. Cada ID del catálogo se puede copiar en su adaptador de código abierto para crear un paquete WorkBuddy revisable.
+
 ### Herramienta CLI npx skills
 
 Para skills específicas, usa la herramienta de línea de comandos `npx skills` para descubrir, añadir y gestionar skills rápidamente. Para parámetros detallados, consulta [vercel-labs/skills](https://github.com/vercel-labs/skills).

--- a/README.ja.md
+++ b/README.ja.md
@@ -90,6 +90,10 @@ GitHub 上のすべての Skill プロジェクトを自動的にインデック
 
 Vercel のリーダーボードである **[skills.sh](https://skills.sh)** を使用して、最も人気のある Skills リポジトリや個々のスキルの使用統計を直感的に確認することもできます。
 
+### WorkBuddy Skill Atlas
+
+WorkBuddy ユーザー向けの **[WorkBuddy Skill Atlas](https://sandbaseai.github.io/workbuddy-skill/)** は、10,000 件を超える公開 `SKILL.md` パスを、不変の GitHub 出典、重複検出、互換性スコア、保守的な静的レビューシグナルとともに索引化しています。カタログ ID をコピーし、オープンソースのアダプターでレビュー可能な WorkBuddy パッケージを作成できます。
+
 ### npx skills CLI ツール
 
 特定のスキルについては、`npx skills` コマンドラインツールを使用して、スキルの発見、追加、管理を迅速に行うことができます。詳細は [vercel-labs/skills](https://github.com/vercel-labs/skills) を参照してください。

--- a/README.ko.md
+++ b/README.ko.md
@@ -90,6 +90,10 @@ GitHub의 모든 스킬 프로젝트를 자동으로 인덱싱하고 카테고�
 
 Vercel의 리더보드인 **[skills.sh](https://skills.sh)**를 사용하여 가장 인기 있는 스킬 저장소와 개별 스킬 사용 통계를 직관적으로 확인할 수 있습니다.
 
+### WorkBuddy Skill Atlas
+
+WorkBuddy 사용자를 위한 **[WorkBuddy Skill Atlas](https://sandbaseai.github.io/workbuddy-skill/)**는 10,000개 이상의 공개 `SKILL.md` 경로를 변경 불가능한 GitHub 출처, 중복 감지, 호환성 점수, 보수적인 정적 검토 신호와 함께 색인화합니다. 카탈로그 ID를 복사해 오픈 소스 어댑터로 검토 가능한 WorkBuddy 패키지를 만들 수 있습니다.
+
 ### npx skills CLI 도구
 
 특정 스킬의 경우, `npx skills` 명령줄 도구를 사용하여 빠르게 발견, 추가 및 관리할 수 있습니다. 자세한 내용은 [vercel-labs/skills](https://github.com/vercel-labs/skills)를 참조하세요.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ It is recommended to use the **[SkillsMP Marketplace](https://skillsmp.com)**, w
 
 You can also use **[skills.sh](https://skills.sh)** — Vercel's leaderboard — to intuitively view the most popular Skills repositories and individual Skill usage statistics.
 
+### WorkBuddy Skill Atlas
+
+For WorkBuddy users, **[WorkBuddy Skill Atlas](https://sandbaseai.github.io/workbuddy-skill/)** indexes more than 10,000 public `SKILL.md` paths with immutable GitHub provenance, duplicate detection, compatibility scoring, and conservative static review signals. Each catalog ID can be copied into its open-source adapter to produce a reviewable WorkBuddy package.
+
 ### npx skills CLI Tool
 
 For specific skills, use the `npx skills` command-line tool to quickly discover, add, and manage skills. For detailed parameters, see [vercel-labs/skills](https://github.com/vercel-labs/skills).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -90,6 +90,10 @@
 
 您也可以使用 **[skills.sh](https://skills.sh)** —— Vercel 的排行榜 —— 直观地查看最受欢迎的 Skills 仓库和单个技能的使用统计数据。
 
+### WorkBuddy Skill Atlas
+
+对于 WorkBuddy 用户，**[WorkBuddy Skill Atlas](https://sandbaseai.github.io/workbuddy-skill/zh-CN.html)** 收录了超过 10,000 个公开 `SKILL.md` 路径，提供不可变 GitHub 来源、重复检测、兼容度评分和保守的静态审查信号。复制目录 ID 后，可用其开源适配器生成便于审核的 WorkBuddy 技能包。
+
 ### npx skills CLI 工具
 
 对于特定技能，使用 `npx skills` 命令行工具快速发现、添加和管理技能。详细参数请参阅 [vercel-labs/skills](https://github.com/vercel-labs/skills)。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -90,6 +90,10 @@
 
 您也可以使用 **[skills.sh](https://skills.sh)** —— Vercel 的排行榜 —— 直觀地查看最受歡迎的 Skills 倉庫和單個技能的使用統計數據。
 
+### WorkBuddy Skill Atlas
+
+對於 WorkBuddy 使用者，**[WorkBuddy Skill Atlas](https://sandbaseai.github.io/workbuddy-skill/zh-CN.html)** 收錄超過 10,000 個公開 `SKILL.md` 路徑，提供不可變 GitHub 來源、重複偵測、相容度評分和保守的靜態審查訊號。複製目錄 ID 後，可用其開源適配器產生便於審查的 WorkBuddy 技能包。
+
 ### npx skills CLI 工具
 
 對於特定技能，使用 `npx skills` 命令行工具快速發現、添加和管理技能。詳細參數請參閱 [vercel-labs/skills](https://github.com/vercel-labs/skills)。


### PR DESCRIPTION
## Summary

- add WorkBuddy Skill Atlas to the skill discovery guide
- explain its immutable GitHub provenance, duplicate detection, compatibility scoring, static review signals, and open-source WorkBuddy adapter
- keep English, Simplified/Traditional Chinese, Japanese, Korean, and Spanish documentation aligned

## Why it belongs here

This is a complementary WorkBuddy-focused discovery path rather than another individual skill listing. It currently indexes 10,200 public `SKILL.md` paths and links every result to an exact GitHub commit.

## Verification

- all three linked destinations return HTTP 200
- `npm run build` in `website/` succeeds
- `git diff --check` succeeds
- `npm run lint` reports the existing 25 React/TypeScript errors in unchanged website files; this documentation-only PR introduces none of them