### PR TITLE
docs: add awesome-workbuddy to related lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -802,6 +802,7 @@ Every skill in this list is a public GitHub repository — you can read the full
 - [awesome-design-md](https://github.com/VoltAgent/awesome-design-md) - Standards and tools for the DESIGN.md protocol.
 - [awesome-openclaw-skills](https://github.com/VoltAgent/awesome-openclaw-skills) - Open source agent skills for OpenClaw.
 - [awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers) - A collection of Model Context Protocol (MCP) servers.
+- [awesome-workbuddy](https://github.com/sandbaseai/awesome-workbuddy) - Bilingual, safety-reviewed skills and MCP directory for WorkBuddy/CodeBuddy.
 
 ---
 


### PR DESCRIPTION
Adds one relevant entry to Related Awesome Lists, following the repository's concise link-list format. The linked directory covers WorkBuddy/CodeBuddy skills, MCP servers, workflows, guides, and open-source projects with safety-review notes.