### PR TITLE
Add WaveSpeedAI skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ Official skills for ML workflows.
 - [fal-ai-community/fal-realtime](https://agent-skill.co/fal-ai-community/skills/fal-realtime) - Real-time and streaming AI image generation
 - [fal-ai-community/fal-upscale](https://agent-skill.co/fal-ai-community/skills/fal-upscale) - Upscale and enhance image resolution
 
+#### Skills by WaveSpeedAI
+- [WaveSpeedAI/agent-skills](https://github.com/WaveSpeedAI/agent-skills) - Generate and edit images, video, audio, and 3D on WaveSpeed via CLI or MCP, plus per-model skills (Seedream, Seedance, Veo 3.1, Wan, Nano Banana, MiniMax Speech, upscalers)
+
 #### Skills by MiniMax
 - [MiniMax-AI/frontend-dev](https://agent-skill.co/MiniMax-AI/skills/frontend-dev) - Frontend with animations and AI media via MiniMax
 - [MiniMax-AI/minimax-pdf](https://agent-skill.co/MiniMax-AI/skills/minimax-pdf) - Generate, fill, and reformat PDFs


### PR DESCRIPTION
Adds a **Skills by WaveSpeedAI** entry under *Official Skill Directories → AI Platforms & Models*, next to Replicate, fal.ai and MiniMax.

- Repo: https://github.com/WaveSpeedAI/agent-skills (MIT)
- One general `wavespeed` skill (search the live catalog, read a model's schema, quote the price, run, upload local files) plus 13 per-model skills: Seedream 4.5, Nano Banana Pro / 2, Seedance 1.5 Pro, Veo 3.1 Fast, Wan 2.6, Wan 2.2 Animate, InfiniteTalk, MiniMax Speech 2.6, image/video upscalers, face swap, watermark removal.
- All skills follow the `SKILL.md` standard; the repo root is an Agent Plugins 1.0 package with an `mcp.json` for the `@wavespeed/mcp` server, so it installs into Kiro, Codex, Qwen Code and OpenHands as-is, and via `npx skills add WaveSpeedAI/agent-skills` everywhere else.
- Skills are also published on ClawHub under `@wavespeed` and scanned clean there.

Single section addition, alphabetical placement kept within the vendor blocks.