### PR TITLE
Add EdgeVerdict to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ That's it. No installation. No configuration. No coding required.
   - [Productivity and Collaboration](#productivity-and-collaboration)
   - [Development and Testing](#development-and-testing)
   - [Context Engineering](#context-engineering)
+  - [Finance / Trading](#finance--trading)
 - [Skill Quality Standards](#skill-quality-standards)
 - [Using Skills](#using-skills)
 - [Creating Skills](#creating-skills)
@@ -557,6 +558,11 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [muratcankoylan/context-compression](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/context-compression) - Compression strategies for long-running sessions
 - [muratcankoylan/memory-systems](https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/tree/main/skills/memory-systems) - Design short-term and graph-based memory architectures
 - [k-kolomeitsev/data-structure-protocol](https://github.com/k-kolomeitsev/data-structure-protocol) - Graph-based memory for faster context and safer refactors
+</details>
+<details>
+<summary><strong>Finance / Trading</strong></summary>
+
+- **EdgeVerdict** — Read-only agent skill for Path A $0.10 micropay signal receipts (unpaid HTTP 402 until paid) + paper waitlist Path B. Method card: https://edgeverdict.io/receipts — `npx skills add edgeverdict/edgeverdict-make-me-money-trading` — https://github.com/edgeverdict/edgeverdict-make-me-money-trading
 </details>
 
 ---


### PR DESCRIPTION
## Summary
- Add EdgeVerdict under a new Finance / Trading community skills category.
- Include the read-only Path A receipt and paper waitlist Path B description, method card, install command, and repository link.

## Test plan
- [x] Verify README formatting with `git diff --check`.