### PR TITLE
Add Skill Forge to Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [zztimur/skill-forge](https://github.com/zztimur/skill-forge) - Validate, pressure-test, and release-gate Agent Skill packages
 </details>
 
 <details>


### PR DESCRIPTION
Adds zztimur/skill-forge under Community Skills / Development and Testing. Skill Forge combines a dependency-free Python package inspector with an agent-led audit workflow for SKILL.md folders, drafts, and ZIP archives.

Source: https://github.com/zztimur/skill-forge
Published release: https://github.com/zztimur/skill-forge/releases/tag/v2.2.1
Example report: https://github.com/zztimur/skill-forge/blob/main/references/example-report.md

The entry links to the maintained source repository. Portable checks are a shared baseline, not certification for every host. Static checks and qualitative pressure-test evidence remain separate.

AI assistance: Codex prepared this listing and its validation on behalf of the repository owner.

Validation: `npm ci --ignore-scripts` and `npm run build` in `website/` passed. The change adds one Markdown link under the existing category. Submission text passed a strict privacy scan.
