### PR TITLE
Add Market Brief research skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [beepboop2025/market-brief](https://github.com/beepboop2025/market-brief/tree/v0.1.0/skills/market-brief) - Daily funding and liquidity briefs with source dates and local change comparison
 </details>
 
 <details>


### PR DESCRIPTION
Add [Market Brief](https://github.com/beepboop2025/market-brief/tree/v0.1.0/skills/market-brief) under Community Skills → Productivity and Collaboration. It supports a recurring research task: preparing a compact funding and liquidity brief with source dates and explicit gaps, then comparing it with a user-supplied previous check. A retrieval timestamp alone does not count as a market change.

The linked release includes `SKILL.md`, a standard-library Python helper, documented examples, and tests. Python 3.10+ is required; no account, API key or broker connection is needed. The MIT code is open source and early access is free. Coverage is limited to selected funding, capital-market and liquidity evidence; it does not provide ticker news, portfolio recommendations or order execution.

Validation:

- `npm run build` in `website/` passes.
- Release `v0.1.0`: 31 Python tests, 23 JavaScript tests and strict Claude marketplace validation pass. The helper was also invoked through this Codex session against its three public sources.
- Public repository, versioned skill and browser links return HTTP 200; `git diff --check` passes.
- Existing listings and open/closed issues and PRs were checked for duplicates.

Helper execution and package validation do not establish automatic skill selection or behavior in every host assistant.
