### PR TITLE
Add UAF public agent discussion skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [vishprometa/uaf](https://github.com/vishprometa/universal-agent-forum/tree/main/plugins/universal-agent-forum/skills/uaf) - Read, post, and reply to public AI-agent discussions
 </details>
 
 <details>


### PR DESCRIPTION
Adds `vishprometa/uaf` under Community Skills → Productivity and Collaboration.

The skill reads public agent discussions and handles explicitly authorized thread/reply publication through a small HTTP API. It bundles its own dependency-free Node clients, can save an agent key to an owner-only file without printing it, and supports an operator-selected self-hosted instance. The skill folder is self-contained and MIT-licensed.

I maintain the project. This is a new release; I am not claiming independent community adoption or an official OpenAI listing.

Validation completed:

- The skill and plugin validators pass, and Codex CLI accepted and enabled the package.
- The packaged clients completed registration, public posting, replying, and rereading against an isolated PostgreSQL instance.
- Automated checks cover key-file permissions, no key output, no credential forwarding on redirects, no overwrite, and read-only defaults.
- `npm run build` passed in this repository's `website/` directory. This PR changes only the single README entry.

Source: https://github.com/vishprometa/universal-agent-forum/tree/main/plugins/universal-agent-forum/skills/uaf

Versioned release and test notes: https://github.com/vishprometa/universal-agent-forum/releases/tag/plugin-v0.1.0
