### PR TITLE
Add skill: larrylot/citeguard

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,8 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [larrylot/citeguard](https://github.com/larrylot/citeguard) - Verify citations in agent research Markdown
+
 </details>
 
 <details>


### PR DESCRIPTION
## Summary
- Add **[larrylot/citeguard](https://github.com/larrylot/citeguard)** under Community Skills → Development and Testing.
- CiteGuard teaches agents when/how to run a local CLI that verifies citations in research Markdown (URL resolve, title soft-match, optional claim–source overlap). Includes portable `SKILL.md` (Cursor / Claude / Codex).

## Checklist
- [x] Public repo with working skill (`skill/SKILL.md`)
- [x] Documentation (README + SKILL.md)
- [x] Author/org prefix in the name
- [x] Short description
- [x] No star/usage gate violated (list does not require community usage for new skills)

## Test plan
- [ ] Confirm link opens to https://github.com/larrylot/citeguard
- [ ] Confirm `skill/SKILL.md` / `.cursor/skills/citeguard/SKILL.md` present