### PR TITLE
Add orca-replay to Community Skills / Development and Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [massimodeluisa/recursive-decomposition-skill](https://github.com/massimodeluisa/recursive-decomposition-skill) - Handle long-context tasks (100+ files) via decomposition
 - [mcollina/skills](https://github.com/mcollina/skills/tree/main/skills) - Node.js core, Fastify, and TypeScript skills by Matteo Collina
 - [Leonxlnx/taste-skill](https://github.com/Leonxlnx/taste-skill) - High-agency frontend skill to eliminate generic UI slop
+- [Continuum-AI-Corp/OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay/tree/main/skills/orca-replay) - Read a recorded agent run from its trace, replay it offline, or fork it onto another model
 </details>
 
 <details>


### PR DESCRIPTION
Adds `orca-replay` to **Community Skills → Development and Testing**.

The skill tells an agent to answer "why did the earlier run do that" from a **recording** rather than from memory or a pasted transcript, and to keep what the trace actually shows separate from what it is inferring. It also covers replaying the run offline and forking it from a checkpoint onto a different model.

**Against your Skill Quality Standards, point by point:**

- *Clear instructions* — the body is a decision procedure, not prose: which tool to call for which question, and what each one can and cannot establish.
- *Appropriate scope* — one task: reading a past run. It does not try to write code or drive the agent.
- *Working examples* — concrete command sequences for each tool.
- *Documented trade-offs* — this is the part it spends most length on. It states that `orca_replay` shows the recorded decisions still reproduce but **cannot** show a fresh run would fail the same way, since the model is not asked again; that an inferred causal edge is not a recorded one; and that `orca_compare` uploads recorded context to third-party providers, spends real money, and runs live agents whose shell commands execute for real.
- *Size limit* — 211 lines, under your 500.
- *Tested* — the MCP server it depends on is verified against the published `orcareplay@0.2.1`: protocol `2025-06-18`, `initialize` and `tools/list` answered, six tools returned. It has been exercised with Claude Code; I have not personally run it inside every agent this list covers.

Apache-2.0. The same file was reviewed and merged into `sickn33/agentic-awesome-skills` and published to ClawHub after its security scan. It needs the `orcareplay` npm package with its MCP server registered, declared in the skill's own frontmatter.
