### PR TITLE
Add ProvenSkills free skill packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [RoundTable02/tutor-skills](https://github.com/RoundTable02/tutor-skills) - Transform docs or codebases into interactive StudyVaults
 - [hanfang/claude-memory-skill](https://github.com/hanfang/claude-memory-skill) - Hierarchical memory system with filesystem persistence
 - [wrsmith108/linear-claude-skill](https://github.com/wrsmith108/linear-claude-skill) - Manage Linear issues, projects, and teams
+- [ProvenSkills free packs](https://provenskills.ai/free) - Five free business skill packs delivered over a hosted MCP connector
 </details>
 
 <details>


### PR DESCRIPTION
Adds ProvenSkills' five free packs under Community Skills, Productivity and Collaboration. They are written by people who run them in their own business and delivered over a hosted MCP connector, so updates arrive without downloads. Free packs: Meeting Ops, Plain Writing, Retention Desk, Claims Desk Field Kit, Skill Author Kit. Site: https://provenskills.ai/free
