### PR TITLE
Add facet to Community Skills > Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Install from [microsoft/agent-skills](https://github.com/microsoft/agent-skills)
 - [AgriciDaniel/claude-seo](https://github.com/AgriciDaniel/claude-seo) - Universal SEO skill for website analysis
 - [smixs/creative-director-skill](https://github.com/smixs/creative-director-skill) - 20+ creative methodologies (SIT, TRIZ, SCAMPER)
 - [SHADOWPR0/beautiful_prose](https://github.com/SHADOWPR0/beautiful_prose) - Hard-edged writing style contract for forceful English prose
+- [jovelove7/facet](https://github.com/jovelove7/facet) - Compare what a brand says with what its product delivers
 </details>
 
 <details>


### PR DESCRIPTION
Adds [facet](https://github.com/jovelove7/facet) under Community Skills > Marketing.

Facet compares what a brand publicly says with what its product actually delivers, then reports where the meaning first changes - in marketing, in the product, or in default UX. It is a verification-first skill: when the promise holds, it says so rather than manufacturing a problem.

Against the quality standards in the README:

**Clear instructions.** `SKILL.md` defines a fixed output contract - the same six sections in the same order every run, with localized labels. Scope rules, evidence rules, hypothesis rules, and diagnosis rules live in separate reference files that load only when an audit needs them.

**Appropriate scope.** One task: auditing a single company's promise against its own product experience. It explicitly does not rank companies, compare vendors, or write replacement copy, and `SKILL.md` states those boundaries.

**Working examples.** Three unedited audits ship with the repo, each with its sources, run date, and audit scope. They land on different results on purpose - one promise held, one broke, and one looked broken but was not, so the method is visible rather than a single rehearsed outcome.

**Size limit.** `SKILL.md` is 178 lines.

Also included: a conclusion-agnostic regression suite that checks the method and the output contract rather than freezing a historical verdict, plus `scripts/check_skill.py` for structural validation in CI.

MIT licensed. Works with Claude Code, Codex, and any Agent Skills client.